### PR TITLE
Fix autodoc on readthedocs.org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ coverage: ## check code coverage quickly with the default Python
 docs: ## generate Sphinx HTML documentation, including API docs
 	rm -f docs/catpy.rst
 	rm -f docs/modules.rst
-	sphinx-apidoc -o docs/ catpy
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	$(BROWSER) docs/_build/html/index.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -280,3 +280,17 @@ texinfo_documents = [
 # Fix numpydoc and autosummary compatibility.
 # See: https://github.com/numpy/numpydoc/pull/6
 numpydoc_class_members_toctree = False
+
+# Run autodoc here, rather than in a Makefile, so that it is also
+# executed by readthedocs.org.
+def run_apidoc(_):
+    from sphinx.apidoc import main
+    import os
+    import sys
+    sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+    cur_dir = os.path.abspath(os.path.dirname(__file__))
+    module = os.path.join('..', project)
+    main(['-e', '-o', cur_dir, module, '--force'])
+
+def setup(app):
+    app.connect('builder-inited', run_apidoc)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'catpy'
-copyright = u"2017, Andrew S. Champion"
+copyright = u"2017, catpy Developers"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout


### PR DESCRIPTION
Proof in the pudding:

http://catpy.readthedocs.io/en/issues-rtd-friendly-name/catpy.html

Also, it seems RTD doesn't like branch names with slashes.