### PR TITLE
client: Instantiate from JSON

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,3 +10,4 @@ pytest==3.0.7
 pytest-cov==2.5.1
 pytest-runner==2.11.1
 PyYAML==3.11
+mock==2.0.0; python_version < '3.6'

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from setuptools import setup
+import sys
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
@@ -22,6 +23,9 @@ setup_requirements = [
 test_requirements = [
     'pytest>=3',
 ]
+
+if sys.version_info < (3, 6):
+    test_requirements.append('mock>=2')
 
 setup(
     name='catpy',

--- a/tests/test_catmaid_client.py
+++ b/tests/test_catmaid_client.py
@@ -1,0 +1,180 @@
+import json
+
+import pytest
+import requests
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+from catpy.client import CatmaidClient, make_url, WrappedCatmaidException
+
+
+BASE_URL = 'http://not-catmaid.org'
+TOKEN = 'abc123'
+
+
+@pytest.fixture
+def credentials_dict():
+    return {
+        'base_url': BASE_URL,
+        'token': TOKEN
+    }
+
+
+@pytest.fixture
+def credentials_file(credentials_dict, tmpdir):
+    p = tmpdir.join('credentials.json')
+    p.write(json.dumps(credentials_dict))
+    return str(p)
+
+
+@pytest.fixture
+def valid_response_dict():
+    return {'msg': 'This response is OK'}
+
+
+@pytest.fixture
+def error_response_dict():
+    return {'traceback': 'a long traceback', 'error': 'an error occurred', 'type': 'a bad one'}
+
+
+@pytest.fixture
+def session_mock():
+    session = mock.Mock()
+    session.auth = None
+    return session
+
+
+@pytest.fixture
+def response_mock():
+    response = mock.Mock()
+    response.headers = {'content-type': 'application/json'}
+    response.status_code = 200
+
+    return response
+
+
+def test_instantiate_creates_session():
+    c = CatmaidClient(BASE_URL)
+    assert isinstance(c._session, requests.Session)
+
+
+def test_can_set_auth():
+    c = CatmaidClient(BASE_URL)
+    assert c._session.auth is None
+    c.set_http_auth('username', 'password')
+    assert c._session.auth == ('username', 'password')
+
+
+def check_correct_token(catmaid_client, token=TOKEN):
+    assert catmaid_client._session.headers['X-Authorization'] == 'Token ' + token
+
+
+def test_can_set_token():
+    c = CatmaidClient(BASE_URL)
+    assert 'X-Authorization' not in c._session.headers
+    c.set_api_token(TOKEN)
+    check_correct_token(c)
+
+
+def test_from_json_pathstr(credentials_file):
+    c = CatmaidClient.from_json(credentials_file)
+    assert c.base_url == BASE_URL
+    check_correct_token(c)
+
+
+def test_from_json_dict(credentials_dict):
+    c = CatmaidClient.from_json(credentials_dict)
+    assert c.base_url == BASE_URL
+    check_correct_token(c)
+
+
+class DummyPath(object):
+    def __init__(self, s):
+        self.s = s
+
+    def __str__(self):
+        return str(self.s)
+
+
+def test_from_json_pathlib(credentials_file):
+    """Test that this would work even on a pathlib/pathlib2 Path instead of a str"""
+    path = DummyPath(credentials_file)
+    c = CatmaidClient.from_json(path)
+    assert c.base_url == BASE_URL
+    check_correct_token(c)
+
+
+def test_get_calls_fetch():
+    params = {'a': 1}
+    with mock.patch.object(CatmaidClient, 'fetch') as fetch:
+        c = CatmaidClient(BASE_URL)
+        c.get('relative', params=params)
+
+    fetch.assert_called_with('relative', method='GET', data=params, raw=False)
+
+
+def test_post_calls_fetch():
+    data = {'a': 1}
+    with mock.patch.object(CatmaidClient, 'fetch') as fetch:
+        c = CatmaidClient(BASE_URL)
+        c.post('relative', data=data)
+
+    fetch.assert_called_with('relative', method='POST', data=data, raw=False)
+
+
+def test_fetch_uses_session(response_mock):
+    url = make_url(BASE_URL, 'relative')
+    with mock.patch.object(requests.Session, 'get', return_value=response_mock) as get:
+        c = CatmaidClient(BASE_URL)
+        c.fetch('relative', 'GET')
+
+    get.assert_called_with(url, params={})
+
+    with mock.patch.object(requests.Session, 'post', return_value=response_mock) as post:
+        c = CatmaidClient(BASE_URL)
+        c.fetch('relative', 'POST')
+
+    post.assert_called_with(url, data={})
+
+
+def test_raises_for_status(response_mock):
+    with mock.patch.object(requests.Session, 'get', return_value=response_mock):
+        c = CatmaidClient(BASE_URL)
+        c.fetch('relative', 'GET')
+
+    response_mock.raise_for_status.assert_called()
+
+
+def test_raises_on_wrapped_error(response_mock):
+    with mock.patch.object(requests.Session, 'get', return_value=response_mock), \
+          mock.patch.object(WrappedCatmaidException, 'raise_on_error') as raise_on_error:
+        c = CatmaidClient(BASE_URL)
+        c.fetch('relative', 'GET')
+
+    raise_on_error.assert_called_with(response_mock)
+
+
+def test_response_json(response_mock, valid_response_dict):
+    response_mock.json.return_value = valid_response_dict
+    with mock.patch.object(requests.Session, 'get', return_value=response_mock):
+        c = CatmaidClient(BASE_URL)
+        ret = c.fetch('relative', 'GET')
+
+    assert ret == valid_response_dict
+
+
+def test_response_raw_no_deserialise(response_mock):
+    response_mock.text = 'text'
+    with mock.patch.object(requests.Session, 'get', return_value=response_mock):
+        c1 = CatmaidClient(BASE_URL)
+        c1.fetch('relative', 'GET', raw=False)
+        count_not_raw = response_mock.json.call_count
+        response_mock.json.reset_mock()
+        ret = c1.fetch('relative', 'GET', raw=True)
+        count_raw = response_mock.json.call_count
+
+    assert count_not_raw == count_raw + 1
+    assert ret == 'text'

--- a/tests/test_catmaid_client_application.py
+++ b/tests/test_catmaid_client_application.py
@@ -1,0 +1,57 @@
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+import pytest
+
+from catpy.client import CatmaidClient, CatmaidClientApplication
+
+
+PROJECT_ID = 10
+BASE_URL = 'http://not-catmaid.org'
+
+
+@pytest.fixture
+def catmaid_mock():
+    catmaid = mock.Mock()
+    catmaid.project_id = PROJECT_ID
+    catmaid.base_url = BASE_URL
+    return catmaid
+
+
+@pytest.fixture
+def ConcreteApp():
+    class Subclass(CatmaidClientApplication):
+        pass
+
+    return Subclass
+
+
+def test_property_passthrough(catmaid_mock, ConcreteApp):
+    app = ConcreteApp(catmaid_mock)
+    assert app.project_id == catmaid_mock.project_id == PROJECT_ID
+    assert app.base_url == catmaid_mock.base_url == BASE_URL
+
+
+def test_method_passthrough(catmaid_mock, ConcreteApp):
+    app = ConcreteApp(catmaid_mock)
+    args = (1, 2)
+    kwargs = {'a': 1}
+
+    app.get(*args, **kwargs)
+    catmaid_mock.get.assert_called_with(*args, **kwargs)
+
+    app.post(*args, **kwargs)
+    catmaid_mock.post.assert_called_with(*args, **kwargs)
+
+    app.fetch(*args, **kwargs)
+    catmaid_mock.fetch.assert_called_with(*args, **kwargs)
+
+
+def test_from_json(ConcreteApp):
+    cred_path = 'cred/path.json'
+    with mock.patch.object(CatmaidClient, 'from_json') as from_json:
+        ConcreteApp.from_json(cred_path)
+
+    from_json.assert_called_with(cred_path)

--- a/tests/test_catpy.py
+++ b/tests/test_catpy.py
@@ -12,8 +12,24 @@ Tests for `catpy.client` module.
 from catpy import client
 
 
-def test_make_url():
+def test_make_url_double_slash():
     """Tests for catpy.client.make_url
     """
     url = client.make_url('foo/', '/bar')
     assert url == 'foo/bar', 'Duplicate slashes should be removed'
+
+
+def test_make_url_no_slash():
+    """Tests for catpy.client.make_url
+    """
+    url = client.make_url('foo', 'bar')
+    assert url == 'foo/bar', 'Elements should be joined with a slash'
+
+
+def test_make_url_trailing_slash_unchanged():
+    """Tests for catpy.client.make_url
+    """
+    url1 = client.make_url('foo', 'bar')
+    assert url1 == 'foo/bar', 'Should not add trailing slash'
+    url2 = client.make_url('foo', 'bar/')
+    assert url2 == 'foo/bar/', 'Should not remove trailing slash'


### PR DESCRIPTION
Previously, someone using a subclass of CatmaidClientApplication would
have to instantiate it using
`CatmaidClientApp(CatmaidClient.from_json(json_path), other, args)`,
which is a little unwieldy.

Now they can do `CatmaidClientApp.from_json(json_path, other, args)`.

Minor changes:

- from_json can take a dict instead of a file containing the
  serialisation of that dict
- base_url can be accessed from the CatmaidClientApplication
- There is no longer an extra switch for whether to look for a project
  ID on instantiation of a CatmaidClient

This last represents an API change but it's extremely minor and I'd be surprised if anyone had used it.