### PR TITLE
Image fetcher, URL builder, unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ htmlcov/
 .tox/
 .coverage
 .coverage.*
-.cache
+.*cache
 nosetests.xml
 coverage.xml
 *,cover

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -f .coverage*
 	rm -fr htmlcov/
 	rm -fr .cache/
+	rm -fr .pytest_cache/
 
 lint: ## check style with flake8
 	flake8 catpy tests

--- a/catpy/__init__.py
+++ b/catpy/__init__.py
@@ -9,4 +9,4 @@ __version__ = '0.1.0'
 __all__ = ['client']
 
 
-from catpy.client import CatmaidClient, CoordinateTransformer  # noqa
+from catpy.client import CatmaidClient, CoordinateTransformer, CatmaidUrl  # noqa

--- a/catpy/client.py
+++ b/catpy/client.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import division, unicode_literals
 
 import json
+import webbrowser
 from functools import wraps
 from abc import ABCMeta
+from warnings import warn
 
 from six import string_types, add_metaclass
 import requests
@@ -461,3 +464,220 @@ class CoordinateTransformer(object):
         translation_arr = self._get_translation_array(dims)
 
         return arr * resolution_arr + translation_arr
+
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return False
+
+        return self.resolution == other.resolution and self.translation == other.translation
+
+
+def get_typed(d, key, constructor=None, default=None):
+    """
+    like dict.get, but if the response/default is not None, pass it to the given constructor.
+
+    Parameters
+    ----------
+    d : dict
+    key : hashable
+    constructor : callable
+    default
+
+    Returns
+    -------
+
+    """
+    response = d.get(key, default)
+    if constructor is None or response is None:
+        return response
+    else:
+        return constructor(response)
+
+
+class CatmaidUrl(object):
+    tracing_tool_name = 'tracingtool'
+
+    def __init__(
+        self, base_url, project_id, stack_group_id=None, stack_id=None, scale=0, x=None, y=None, z=None,
+        tool=None, active_skeleton_id=None, active_node_id=None
+    ):
+        self.base_url = base_url
+
+        self.project_id = project_id
+
+        self.default_scale = scale
+
+        self.stack_group = None
+        self.stack_group_scale = None
+        self.stacks = []
+        self.set_stack_group(stack_group_id, scale)
+        if stack_id is not None:
+            self.add_stack(stack_id, scale)
+
+        self.x = x
+        self.y = y
+        self.z = z
+
+        self.tool = tool
+        self.active_skeleton_id = active_skeleton_id
+        self.active_node_id = active_node_id
+
+    @classmethod
+    def from_catmaid(
+        cls, catmaid_client, stack_group_id=None, stack_id=None, scale=0, x=None, y=None, z=None,
+        tool=None, active_skeleton_id=None, active_node_id=None
+    ):
+        """
+        Instantiate CatmaidUrl based on a CATMAID interface instance.
+
+        Parameters
+        ----------
+        catmaid_client : CatmaidClient or CatmaidClientApplication
+        stack_group_id : int
+        stack_id : int
+        scale : float
+        x : float
+            x coordinate in project (real) space
+        y : float
+            y coordinate in project (real) space
+        z : float
+            z coordinate in project (real) space
+        tool : str
+        active_skeleton_id : int
+        active_node_id : int
+
+        Returns
+        -------
+        CatmaidUrl
+        """
+        return cls(catmaid_client.base_url, catmaid_client.project_id, stack_group_id, stack_id, scale, x, y, z,
+                   tool, active_skeleton_id, active_node_id)
+
+    @classmethod
+    def from_url(cls, url):
+        """
+        Instantiate CatmaidUrl based on a URL pulled from a running CATMAID instance.
+
+        Parameters
+        ----------
+        url : str
+
+        Returns
+        -------
+        CatmaidUrl
+        """
+        base_url, args = url.split('/?')
+        d = dict(item.split('=') for item in args.split('&'))
+
+        kwargs = dict(
+            project_id=get_typed(d, 'pid', int), scale=None,
+            x=get_typed(d, 'xp', float), y=get_typed(d, 'yp', float), z=get_typed(d, 'zp', float),
+            tool=d.get('tool'),
+            active_skeleton_id=get_typed(d, 'active_skeleton_id', int),
+            active_node_id=get_typed(d, 'active_node_id', int)
+        )
+
+        obj = cls(base_url, **kwargs)
+        obj.set_stack_group(stack_group_id=int(d.get('sg')), scale=float(d.get('sgs')))
+
+        stacks = dict()
+        scales = dict()
+        for key, value in d.items():
+            if key.startswith('sid'):
+                try:
+                    stacks[int(key[3:])] = int(value)
+                except ValueError:
+                    pass
+            elif key.startswith('s'):
+                try:
+                    scales[int(key[1:])] = int(value)
+                except ValueError:
+                    pass
+
+        for idx, sid in sorted(stacks.items(), key=lambda x: (x[1], x[0])):
+            obj.add_stack(sid, scales.get(idx))
+
+        if obj.default_scale is None:
+            obj.default_scale = 0
+
+        return obj
+
+    def add_stack(self, stack_id, scale=None):
+        """
+        Parameters
+        ----------
+        stack_id : int
+        scale : float
+
+        Returns
+        -------
+        CatmaidUrl
+            A reference to itself, for chaining
+        """
+        # todo? fetch stack ID from stack name
+        self.stacks.append((stack_id, scale))
+        if self.default_scale is None:
+            self.default_scale = scale
+        return self
+
+    def set_stack_group(self, stack_group_id, scale=None):
+        """
+        Parameters
+        ----------
+        stack_group_id : int
+        scale : float
+
+        Returns
+        -------
+        CatmaidUrl
+            A reference to itself, for chaining
+        """
+        # todo? fetch stacks from stack group
+        self.stack_group = stack_group_id
+        self.stack_group_scale = scale
+        if self.default_scale is None:
+            self.default_scale = scale
+        return self
+
+    def _terminate_base_url(self):
+        url = self.base_url
+        if url.endswith('/'):
+            url += '?'
+        if not url.endswith('/?'):
+            url += '/?'
+
+        return url
+
+    def __str__(self):
+        elements = ['pid={}'.format(self.project_id)]
+
+        coords = ['{}p={}'.format(dim, float(getattr(self, dim))) for dim in 'xyz' if getattr(self, dim) is not None]
+        if len(coords) == 3:
+            elements.extend(coords)
+        elif coords:
+            warn('Only {} of 3 coordinates found, ignoring'.format(len(coords)))
+
+        if self.tool:
+            elements.append('tool=' + self.tool)
+            if self.tool == 'tracingtool':
+                elements.append('active_node_id={}'.format(self.active_node_id))
+                elements.append('active_skeleton_id={}'.format(self.active_skeleton_id))
+
+        if self.stack_group is not None:
+            elements.append('sg={}'.format(self.stack_group))
+            elements.append(
+                'sgs={}'.format(
+                    float(self.stack_group_scale) if self.stack_group_scale is not None else float(self.default_scale)
+                )
+            )
+
+        if not self.stacks:
+            warn('No stacks added found, URL may be invalid')
+        for idx, (stack_id, scale) in enumerate(self.stacks):
+            elements.append('sid{}={}'.format(idx, stack_id))
+            elements.append('s{}={}'.format(idx, float(scale) if scale is not None else float(self.default_scale)))
+
+        return self._terminate_base_url() + '&'.join(elements)
+
+    def open(self):
+        webbrowser.open(str(self), new=2)

--- a/catpy/image.py
+++ b/catpy/image.py
@@ -398,12 +398,13 @@ class ProjectStack(Stack):
 
         Parameters
         ----------
+        dimension : dict
+            {'x': x, 'y': y, 'z': z}, size of stack in voxels
         translation : dict
             {'x': x, 'y': y, 'z': z}, origin of stack in project space
         resolution : dict
             {'x': x, 'y': y, 'z': z}, size of stack voxels in project units
-        dimension : dict
-            {'x': x, 'y': y, 'z': z}, size of stack in voxels
+        orientation : {'xy', 'xz' 'zy'}
         broken_slices : iterable of int
             z-slice indices which are missing from stack
         canary_location : dict
@@ -551,7 +552,7 @@ class ImageFetcher(object):
         self.timeout = timeout
 
         self.coord_trans = CoordinateTransformer(
-            *[getattr(self.stack, name, None) for name in ('resolution', 'translation')]
+            *[getattr(self.stack, name, None) for name in ('resolution', 'translation', 'orientation')]
         )
 
         self.tqdm = tqdm if self.show_progress else DummyTqdm

--- a/catpy/image.py
+++ b/catpy/image.py
@@ -1,0 +1,1030 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, unicode_literals
+
+from io import BytesIO
+from collections import OrderedDict
+from timeit import timeit
+import itertools
+from warnings import warn
+
+from concurrent.futures import Future, as_completed
+from enum import IntEnum, Enum
+
+import sys
+from six import string_types
+
+from PIL import Image
+import numpy as np
+import requests
+from requests_futures.sessions import FuturesSession
+
+from catpy import CoordinateTransformer
+
+
+class DummyTqdm(object):
+    def __init__(self, iterable, *args, **kwargs):
+        self.iterable = iterable
+
+    def __iter__(self):
+        return iter(self.iterable)
+
+    def write(self, s):
+        sys.stdout.write(s)
+
+
+try:
+    from tqdm import tqdm
+    imported_tqdm = True
+except ImportError:
+    warn('Install tqdm for tile download progress bars')
+    tqdm = DummyTqdm
+    imported_tqdm = False
+
+
+DEFAULT_CACHE_ITEMS = 10
+DEFAULT_CACHE_BYTES = None
+THREADS = 10
+
+SUPPORTED_CONTENT_TYPES = {
+    'image/png',
+    'image/jpeg'
+}
+
+
+class StrEnum(Enum):
+    def __str__(self):
+        return str(self.value)
+
+
+class Orientation3D(StrEnum):
+    NUMPY = 'zyx'
+    C = 'zyx'
+    ZYX = 'zyx'
+    VIGRA = 'xyz'
+    FORTRAN = 'xyz'
+    XYZ = 'xyz'
+
+
+DEFAULT_3D_ORIENTATION = Orientation3D.NUMPY
+
+
+class BrokenSliceHandling(StrEnum):
+    FILL = 'fill'
+    # ABOVE = 'above'
+    # BELOW = 'below'
+    # CLOSEST = 'closest'
+    # INTERPOLATE = 'interpolate'
+
+
+DEFAULT_BROKEN_SLICE_HANDLING = BrokenSliceHandling.FILL
+
+
+class ROIMode(StrEnum):
+    STACK = 'stack'
+    SCALED = 'scaled'
+    PROJECT = 'project'
+
+
+DEFAULT_ROI_MODE = ROIMode.STACK
+
+
+class TileSourceType(IntEnum):
+    FILE_BASED = 1
+    FILE_BASED_WITH_ZOOM_DIRS = 4
+    DIR_BASED = 5
+    RENDER_SERVICE = 7
+    FLIXSERVER = 9
+
+
+format_urls = {
+    TileSourceType.FILE_BASED: '{image_base}{{depth}}/{{row}}_{{col}}_{{zoom_level}}.{file_extension}',
+    TileSourceType.FILE_BASED_WITH_ZOOM_DIRS: '{image_base}{{depth}}/{{zoom_level}}/{{row}}_{{col}}.{file_extension}',
+    TileSourceType.DIR_BASED: '{image_base}{{zoom_level}}/{{depth}}/{{row}}/{{col}}.{file_extension}',
+    TileSourceType.RENDER_SERVICE: '{image_base}largeDataTileSource/{tile_width}/{tile_height}/'
+                                   '{{zoom_level}}/{{depth}}/{{row}}/{{col}}.{file_extension}',
+    TileSourceType.FLIXSERVER: '{image_base}{{depth}}/{{row}}_{{col}}_{{zoom_level}}.{file_extension}',
+}
+
+
+def response_to_array(response, pil_kwargs=None):
+    response.raise_for_status()
+    content_type = response.headers['Content-Type']
+
+    if content_type in SUPPORTED_CONTENT_TYPES:
+        buffer = BytesIO(response.content)  # opening directly from raw response doesn't work for JPEGs
+        raw_img = Image.open(buffer)
+        pil_kwargs = dict(pil_kwargs) if pil_kwargs else dict()
+        pil_kwargs['mode'] = pil_kwargs.get('mode', 'L')
+        grey_img = raw_img.convert(**pil_kwargs)
+        return np.array(grey_img)
+    else:
+        raise NotImplementedError('Image fetching is only implemented for greyscale PNG and JPEG, not {}'.format(
+            content_type.upper().split('/')[1]
+        ))
+
+
+def response_to_array_callback(session, response):
+    response.array = response_to_array(response)
+
+
+def as_future(item):
+    if isinstance(item, Future):
+        return item
+    f = Future()
+    f.set_result(item)
+    return f
+
+
+def fill_tiled_cuboid(min_tile_idx, max_tile_idx):
+    if not min_tile_idx.is_comparable(max_tile_idx):
+        raise ValueError('Tile indices are not comparable (different zoom or size)')
+
+    iters = [range(getattr(min_tile_idx, name), getattr(max_tile_idx, name) + 1) for name in ('depth', 'row', 'col')]
+    return {
+        TileIndex(depth, row, col, min_tile_idx.zoom_level, min_tile_idx.height, min_tile_idx.width)
+        for depth, row, col in itertools.product(*iters)
+    }
+
+
+def dict_subtract(d1, d2):
+    if set(d1) != set(d2):
+        raise ValueError("Dicts have different keys")
+
+    out = dict()
+    for key in d1.keys():
+        out[key] = d1[key] - d2[key]
+    return out
+
+
+def is_valid_format_url(format_url):
+    """
+    Ensure that the given URL has the required format keys for use as a format URL.
+
+    Parameters
+    ----------
+    format_url : str
+
+    Returns
+    -------
+    bool
+    """
+    components = ['image_base', '{depth}', '{zoom_level}', '{row}', '{col}', 'file_extension']
+    return all('{' + component + '}' in format_url for component in components)
+
+
+class TileIndex(object):
+    hash_keys = ('depth', 'row', 'col', 'zoom_level', 'height', 'width')
+    url_keys = ('depth', 'row', 'col', 'zoom_level')
+    comparable_keys = ('zoom_level', 'height', 'width')
+
+    def __init__(self, depth, row, col, zoom_level, height, width):
+        """
+
+        Parameters
+        ----------
+        depth : int
+            z-index
+        row : int
+            y-index
+        col : int
+            x-index
+        zoom_level : int
+        height : int
+            Scaled pixels
+        width : int
+            Scaled pixels
+        """
+        self.depth = depth
+        self.row = row
+        self.col = col
+        self.zoom_level = zoom_level  # todo: not actually necessary?
+        self.height = height
+        self.width = width
+
+    @property
+    def coords(self):
+        """
+        Calculate the coordinates of the tile's upper left corner, in scaled stack coordinates.
+
+        Returns
+        -------
+        dict
+        """
+        return {
+            'x': self.width * self.col,
+            'y': self.height * self.row,
+            'z': self.depth
+        }
+
+    def is_comparable(self, other):
+        return all(getattr(self, key) == getattr(other, key, None) for key in self.comparable_keys)
+
+    @property
+    def url_kwargs(self):
+        return {key: getattr(self, key) for key in self.url_keys}
+
+    def __repr__(self):
+        return 'TileIndex({})'.format(', '.join('{}={}'.format(key, getattr(self, key)) for key in self.hash_keys))
+
+    def __hash__(self):
+        return hash(tuple(getattr(self, name) for name in self.hash_keys))
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
+
+
+class StackMirror(object):
+    def __init__(self, image_base, tile_height, tile_width, tile_source_type, file_extension, title=None, position=0):
+        """
+        Representation of CATMAID stack mirror
+
+        Parameters
+        ----------
+        image_base : str
+        tile_width : int
+        tile_height : int
+        tile_source_type : int or TileSourceType
+        file_extension : str
+        title : str
+        position : int
+        """
+        self.image_base = image_base if image_base.endswith('/') else image_base + '/'
+        self.tile_height = int(tile_height)
+        self.tile_width = int(tile_width)
+        self.tile_source_type = TileSourceType(tile_source_type)
+        self.file_extension = file_extension[1:] if file_extension.startswith('.') else file_extension
+        self.title = str(title)
+        self.position = int(position)
+
+        self.format_url = format_urls[self.tile_source_type].format(**self.__dict__)
+
+    def generate_url(self, tile_index):
+        """
+        Generate absolute URL to desired image
+
+        Parameters
+        ----------
+        tile_index : TileIndex
+
+        Returns
+        -------
+        str
+        """
+        if tile_index.height != self.tile_height and tile_index.width != self.tile_width:
+            raise ValueError('Given TileIndex is not compatible with this stack mirror')
+        return self.format_url.format(**tile_index.url_kwargs)
+
+    def get_tile_index(self, scaled_coords, zoom_level=0):
+        """
+
+        Parameters
+        ----------
+        scaled_coords : dict
+        zoom_level : int
+
+        Returns
+        -------
+        tuple of (TileIndex, dict)
+            Index of tile on which this pixel appears, and its offset from the top left shallow corner of that tile
+        """
+        tile_idx = TileIndex(
+            depth=int(scaled_coords['z']),
+            row=int(scaled_coords['y'] / self.tile_height),
+            col=int(scaled_coords['x'] / self.tile_width),
+            zoom_level=zoom_level,
+            height=self.tile_height,
+            width=self.tile_width
+        )
+
+        tile_coords = tile_idx.coords
+        offset = {dim: scaled_coords[dim] - tile_coords[dim] for dim in 'xyz'}
+
+        return tile_idx, offset
+
+    @classmethod
+    def from_dict(cls, d):
+        """
+        Instantiate StackMirror from one of the items in the 'mirrors' list supplied under
+        CATMAID's {project_id}/stack/{stack_id}/info endpoint
+
+        Parameters
+        ----------
+        d : dict
+
+        Returns
+        -------
+        StackMirror
+        """
+        return cls(
+            d['image_base'], d['tile_height'], d['tile_width'], d['tile_source_type'],
+            d['file_extension'], d['title'], d['position']
+        )
+
+
+class Stack(object):
+    def __init__(self, dimension, broken_slices=None, canary_location=None):
+        """
+        Representation of an image stack which could be used by CATMAID.
+
+        Parameters
+        ----------
+        dimension : dict
+            {'x': x, 'y': y, 'z': z}, size of stack in voxels
+        broken_slices : iterable of int
+            z-slice indices which are missing from stack
+        canary_location : dict
+            {'x': x, 'y': y, 'z': z}
+        """
+        self.dimension = dimension
+        self.broken_slices = {int(s) for s in broken_slices} if broken_slices else set()
+        self.canary_location = canary_location or {'x': 0, 'y': 0, 'z': 0}
+        self.mirrors = []
+
+    def get_fastest_mirror(self, timeout=1, reps=1, normalise_by_tile_size=True):
+        """
+        Determine the fastest accessible mirror.
+
+        Parameters
+        ----------
+        timeout : float
+            Timeout in seconds for each request to the tile server
+        reps : int
+            How many times to fetch the canary tile, for robustness
+        normalise_by_tile_size : bool
+            Whether to normalise the fetch time by the tile size used by this mirror (to get per-pixel response time)
+
+        Returns
+        -------
+        StackMirror
+        """
+        response_times = []
+
+        tqdm_kwargs = {
+            'ncols': 80,
+            'unit': 'mirrors',
+            'desc': 'Checking mirrors'
+        }
+        for mirror in DummyTqdm(self.mirrors, **tqdm_kwargs):
+            tile_index, _ = mirror.get_tile_index(self.canary_location)
+            url = mirror.generate_url(tile_index)
+
+            try:
+                response_time = timeit(lambda: requests.get(url, timeout=timeout), number=reps)
+                if normalise_by_tile_size:
+                    response_time /= tile_index.width * tile_index.height
+                response_times.append((mirror, response_time))
+            except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
+                continue
+
+        if not response_times:
+            raise ValueError('No reachable mirrors found')
+
+        return min(response_times, key=lambda pair: pair[1])[0]
+
+
+class ProjectStack(Stack):
+    def __init__(self, dimension, translation, resolution, orientation, broken_slices=None, canary_location=None):
+        """
+        Representation of an image stack as it pertains to a CATMAID project
+
+        Parameters
+        ----------
+        translation : dict
+            {'x': x, 'y': y, 'z': z}, origin of stack in project space
+        resolution : dict
+            {'x': x, 'y': y, 'z': z}, size of stack voxels in project units
+        dimension : dict
+            {'x': x, 'y': y, 'z': z}, size of stack in voxels
+        broken_slices : iterable of int
+            z-slice indices which are missing from stack
+        canary_location : dict
+            {'x': x, 'y': y, 'z': z}
+        """
+        super(ProjectStack, self).__init__(dimension, broken_slices, canary_location)
+        self.translation = translation
+        self.resolution = resolution
+        self.orientation = orientation
+
+    @classmethod
+    def from_stack_info(cls, stack_info):
+        """
+        Instantiate Stack from the response supplied by CATMAID's {project_id}/stack/{stack_id}/info endpoint
+
+        Parameters
+        ----------
+        stack_info : dict
+
+        Returns
+        -------
+        Stack
+        """
+        stack = cls(
+            stack_info['dimension'], stack_info['translation'], stack_info['resolution'],
+            stack_info['orientation'], stack_info['broken_slices'], stack_info['canary_location']
+        )
+        mirrors = [StackMirror.from_dict(d) for d in stack_info['mirrors']]
+
+        stack.mirrors.extend(sorted(mirrors, key=lambda m: (m.position, m.title)))
+        return stack
+
+
+class TileCache(object):
+    def __init__(self, max_items=DEFAULT_CACHE_ITEMS, max_bytes=DEFAULT_CACHE_BYTES):
+        super(TileCache, self).__init__()
+        self.max_bytes = max_bytes
+        self.max_items = max_items
+        self._dict = OrderedDict()
+
+    @property
+    def current_bytes(self):
+        """
+        Current total size, in bytes, of the cache's values
+
+        Returns
+        -------
+        int
+        """
+        if self.max_bytes is None:
+            return -1
+
+        return sum(value.nbytes for value in self._dict.values())
+
+    def push(self, key, value):
+        """
+        Append value to cache under the given key. If this causes the cache to break the size constraints, remove the
+        oldest items until it is valid again.
+
+        Parameters
+        ----------
+        key : TileIndex
+        value : np.ndarray
+        """
+        if key in self._dict:
+            del self._dict[key]
+        self._dict[key] = value
+        self._constrain_size()
+
+    def get(self, key):
+        return self._dict[key]
+
+    def clear(self):
+        self._dict.clear()
+
+    def __contains__(self, item):
+        return item in self._dict
+
+    def __len__(self):
+        return len(self._dict)
+
+    def __iter__(self):
+        return iter(self._dict)
+
+    def _constrain_size(self):
+        if self.max_items is not None:
+            while len(self) > self.max_items:
+                self._dict.popitem(False)
+
+        if self.max_bytes is not None:
+            total_bytes = self.current_bytes
+            while total_bytes > self.max_bytes:
+                removed = self._dict.popitem(False)
+                total_bytes -= removed[1].nbytes
+
+
+class ImageFetcher(object):
+    show_progress = imported_tqdm
+
+    def __init__(
+        self, stack, output_orientation=DEFAULT_3D_ORIENTATION, preferred_mirror=None, timeout=1,
+        cache_items=DEFAULT_CACHE_ITEMS, cache_bytes=DEFAULT_CACHE_BYTES,
+        broken_slice_handling=DEFAULT_BROKEN_SLICE_HANDLING, cval=0
+    ):
+        """
+
+        Parameters
+        ----------
+        stack : Stack
+        output_orientation : str or Orientation3D
+            default Orientation3D.ZYX
+        preferred_mirror : int or str or StackMirror or None
+            default None
+        timeout : float
+            default 1
+        cache_items : int or None
+            default 10
+        cache_bytes : int or None
+            default None
+        broken_slice_handling : str or BrokenSliceHandling
+            default BrokenSliceHandling.FILL
+        cval : int
+            default 0
+        """
+        self.stack = stack
+        self.depth_dimension = 'z'
+        self.source_orientation = self.depth_dimension + 'yx'
+
+        self.broken_slice_handling = BrokenSliceHandling(broken_slice_handling)
+
+        if self.broken_slice_handling == BrokenSliceHandling.FILL:
+            self.cval = cval
+        else:
+            self.cval = None
+
+        self.target_orientation = str(output_orientation)
+
+        self._dimension_mappings = self._map_dimensions()
+
+        self._mirror = None
+        self.mirror = preferred_mirror
+
+        self.timeout = timeout
+
+        self.coord_trans = CoordinateTransformer(
+            *[getattr(self.stack, name, None) for name in ('resolution', 'translation')]
+        )
+
+        self.tqdm = tqdm if self.show_progress else DummyTqdm
+
+        self._tile_cache = TileCache(cache_items, cache_bytes)
+        # todo: handle HTTP auth?
+        self._session = requests.Session()
+
+    @property
+    def mirror(self):
+        if not self._mirror:
+            warn(
+                'No mirror set: falling back to {}, which may not be accessible.'
+                'You might want to run set_fastest_mirror.'.format(self.stack.mirrors[0].title)
+            )
+            return self.stack.mirrors[0]
+        return self._mirror
+
+    @mirror.setter
+    def mirror(self, preferred_mirror):
+        """
+        Set mirror by its string name, its position attribute, or the object itself
+
+        Parameters
+        ----------
+        preferred_mirror : str or int or StackMirror
+        """
+        if preferred_mirror is None:
+            self._mirror = None
+            return
+        if isinstance(preferred_mirror, StackMirror):
+            if preferred_mirror not in self.stack.mirrors:
+                raise ValueError("Selected mirror is not in stack's mirrors")
+            self._mirror = preferred_mirror
+            return
+
+        try:
+            pos = int(preferred_mirror)
+            matching_mirrors = [m for m in self.stack.mirrors if m.position == pos]
+            if not matching_mirrors:
+                warn('Preferred mirror position {} does not exist, choose from {}'.format(
+                    pos, ', '.join(str(m.position) for m in self.stack.mirrors)
+                ))
+                return
+            elif len(matching_mirrors) > 1:
+                warn('More than one mirror found for position {}, picking {}'.format(
+                    pos, matching_mirrors[0].title
+                ))
+            self._mirror = matching_mirrors[0]
+            return
+        except (ValueError, TypeError):
+            pass
+
+        if isinstance(preferred_mirror, string_types):
+            matching_mirrors = [m for m in self.stack.mirrors if m.title == preferred_mirror]
+            if not matching_mirrors:
+                warn('Preferred mirror called {} does not exist, choose from {}'.format(
+                    preferred_mirror, ', '.join(m.title for m in self.stack.mirrors)
+                ))
+                return
+            elif len(matching_mirrors) > 1:
+                warn('More than one mirror found for title {}, picking first'.format(preferred_mirror))
+            self._mirror = matching_mirrors[0]
+
+    def clear_cache(self):
+        self._tile_cache.clear()
+
+    def _map_dimensions(self):
+        """
+        Find the indices of the target dimensions in the source dimension order
+
+        Returns
+        -------
+        tuple of int
+
+        Examples
+        --------
+        >>> self.source_orientation = 'xyz'
+        >>> self.target_orientation = 'yzx'
+        >>> self._map_dimensions()
+        (1, 2, 0)
+        """
+        mapping = {dim: idx for idx, dim in enumerate(self.source_orientation)}
+        return tuple(mapping[dim] for dim in self.target_orientation)
+
+    def _reorient_volume_src_to_tgt(self, volume):
+        arr = np.asarray(volume)
+        if len(arr.shape) == 2:
+            arr = np.expand_dims(arr, 0)
+        if len(arr.shape) != 3:
+            raise ValueError('Unknown dimension of volume: should be 2D or 3D')
+        return np.moveaxis(arr, (0, 1, 2), self._dimension_mappings)
+
+    def _get_tile(self, tile_index):
+        """
+        Get the tile from the cache, handle broken slices, or fetch.
+
+        Parameters
+        ----------
+        tile_index : TileIndex
+
+        Returns
+        -------
+        Future
+        """
+        try:
+            return self._tile_cache.get(tile_index)
+        except KeyError:
+            pass
+
+        if tile_index.depth in self.stack.broken_slices:
+            if self.broken_slice_handling == BrokenSliceHandling.FILL and self.cval is not None:
+                tile = np.empty((tile_index.width, tile_index.height))
+                tile.fill(self.cval)
+                return tile
+            else:
+                raise NotImplementedError(
+                    "'fill' with a non-None cval is the only implemented broken slice handling mode"
+                )
+
+        return self._fetch(tile_index)
+
+    def _roi_to_tiles(self, roi_src, zoom_level):
+        """
+
+        Parameters
+        ----------
+        roi_src : array-like
+            2 x 3 array where the rows are the half-closed interval of which pixels to select in the given dimension
+            and at the given zoom level, and the columns are the 3 dimensions in the source orientation
+        zoom_level : int
+            Zoom level at which roi is scaled and which images will be fetched
+
+        Returns
+        -------
+        set of TileIndex
+            Set of tile indices to fetch
+        dict of {str to dict of {str to int}}
+            {'min': {}, 'max': {}} with values {'x': int, 'y': int, 'z': int}
+            Pixel offsets of the minimum maximum pixels from the shallow-top-left corner of the tile which they are on
+        """
+        closed_roi = np.array(roi_src)
+        closed_roi[1, :] -= 1
+        min_pixel = dict(zip(self.source_orientation, closed_roi[0, :]))
+        max_pixel = dict(zip(self.source_orientation, closed_roi[1, :]))
+
+        min_tile, min_offset = self.mirror.get_tile_index(min_pixel, zoom_level)
+        max_tile, max_offset = self.mirror.get_tile_index(max_pixel, zoom_level)
+
+        tile_indices = fill_tiled_cuboid(min_tile, max_tile)
+        src_inner_slicing = {'min': min_offset, 'max': max_offset}
+
+        return tile_indices, src_inner_slicing
+
+    def _insert_tile_into_arr(self, tile_index, src_tile, min_tile, max_tile, src_inner_slicing, out):
+        min_col = tile_index.col == min_tile.col
+        max_col = tile_index.col == max_tile.col
+
+        min_row = tile_index.row == min_tile.row
+        max_row = tile_index.row == max_tile.row
+
+        tile_slicing_dict = {
+            'z': slice(None),
+            'y': slice(
+                src_inner_slicing['min']['y'] if min_row else None,
+                src_inner_slicing['max']['y'] + 1 if max_row else None
+            ),
+            'x': slice(
+                src_inner_slicing['min']['x'] if min_col else None,
+                src_inner_slicing['max']['x'] + 1 if max_col else None
+            ),
+        }
+
+        tile_slicing = tuple(tile_slicing_dict[dim] for dim in self.source_orientation if dim in 'xy')
+
+        tgt_tile = self._reorient_volume_src_to_tgt(src_tile[tile_slicing])
+
+        untrimmed_topleft = dict_subtract(tile_index.coords, min_tile.coords)
+        # location of the top left of the tile in out
+        topleft_dict = {
+            'z': untrimmed_topleft['z'],  # we don't trim in Z
+            'y': 0 if min_row else untrimmed_topleft['y'] - src_inner_slicing['min']['y'],
+            'x': 0 if min_col else untrimmed_topleft['x'] - src_inner_slicing['min']['x'],
+        }
+        topleft = tuple(topleft_dict[dim] for dim in self.target_orientation)
+
+        arr_slice = tuple(slice(tl, tl + s) for tl, s in zip(topleft, tgt_tile.shape))
+        out[arr_slice] = tgt_tile
+
+    def _iter_tiles(self, tile_indices):
+        for tile_idx in tile_indices:
+            yield self._get_tile(tile_idx), tile_idx
+
+    def _assemble_tiles(self, tile_indices, src_inner_slicing, out):
+        """
+
+        Parameters
+        ----------
+        tile_indices : list of TileIndex
+            tiles to be got, reoriented, and compiled.
+        src_inner_slicing : dict of str to {dict of str to int}
+            {'min': {}, 'max': {}} with values {'x': int, 'y': int, 'z': int}
+        out : array-like
+            target-spaced, into which the tiles will be written
+
+        Returns
+        -------
+        np.ndarray
+        """
+        min_tile = min(tile_indices, key=lambda idx: (idx.depth, idx.row, idx.col))
+        max_tile = max(tile_indices, key=lambda idx: (idx.depth, idx.row, idx.col))
+
+        tqdm_kwargs = {
+            'total': len(tile_indices),
+            'ncols': 80,
+            'unit': 'tiles',
+            'desc': 'Downloading tiles'
+        }
+        for src_tile, tile_index in self.tqdm(self._iter_tiles(tile_indices), **tqdm_kwargs):
+            self._tile_cache.push(tile_index, src_tile)
+            self._insert_tile_into_arr(tile_index, src_tile, min_tile, max_tile, src_inner_slicing, out)
+
+        return out
+
+    def _fetch(self, tile_index):
+        """
+
+        Parameters
+        ----------
+        tile_index : TileIndex
+
+        Returns
+        -------
+        Future of np.ndarray in source orientation
+        """
+        url = self.mirror.generate_url(tile_index)
+        return response_to_array(self._session.get(url, timeout=self.timeout))
+
+    def _reorient_roi_tgt_to_src(self, roi_tgt):
+        return roi_tgt[:, self._dimension_mappings]
+
+    def roi_to_scaled(self, roi, roi_mode, zoom_level):
+        """
+        Convert ROI into scaled stack space, keeping in the target dimension order.
+
+        Parameters
+        ----------
+        roi : np.ndarray
+            ROI as 2x3 array containing half-closed bounds in the target dimension order
+        roi_mode : ROIMode or str
+            Whether the ROI is in "project", "stack", or "scaled" stack coordinates
+        zoom_level : float
+            The desired zoom level of the returned data
+
+        Returns
+        -------
+        np.ndarray
+            ROI as 2x3 array containing half-closed bounds in scaled stack space in the target dimension order
+        """
+        roi_mode = ROIMode(roi_mode)
+        roi_tgt = np.asarray(roi)
+
+        if zoom_level != int(zoom_level):
+            raise NotImplementedError('Non-integer zoom level is not supported')
+
+        if roi_mode == ROIMode.PROJECT:
+            if not isinstance(self.stack, ProjectStack):
+                raise ValueError("ImageFetcher's stack is not related to a project, cannot use ROIMode.PROJECT")
+            roi_tgt = self.coord_trans.project_to_stack_array(roi_tgt, dims=self.target_orientation)
+            roi_mode = ROIMode.STACK
+
+        if roi_mode == ROIMode.STACK:
+            roi_tgt = self.coord_trans.stack_to_scaled_array(roi_tgt, zoom_level, dims=self.target_orientation)
+            roi_mode = ROIMode.SCALED
+
+        if roi_mode == ROIMode.SCALED:
+            roi_tgt = np.array([np.floor(roi_tgt[0, :]), np.ceil(roi_tgt[1, :])], dtype=int)
+        else:
+            raise ValueError('Mismatch between roi_mode and roi')  # shouldn't be possible
+
+        return roi_tgt
+
+    def get(self, roi, roi_mode=ROIMode.STACK, zoom_level=0, out=None):
+        """
+        Fetch image data in the ROI in the dimension order of the target orientation.
+
+        ROI modes:
+            ROIMode.PROJECT ('project'):
+                - `roi` is given in project space
+                - `zoom_level` specifies the zoom level of returned data
+                - Returned array may overflow desired ROI by < 1 scaled pixel per side
+            ROIMode.STACK ('stack'):
+                - Default option
+                - `roi` is given in unscaled stack space (i.e. pixels at zoom level 0)
+                - `zoom_level` specifies the desired zoom level of returned data
+                - Returned array may overflow desired ROI by < 1 scaled pixel per side
+                - Equivalent to ROIMode.SCALED if `zoom_level` == 0
+            ROIMode.SCALED ('scaled'):
+                - `roi` is given in scaled stack space at the given zoom level.
+                - `zoom_level` specifies the zoom level of ROI and returned data
+                - Returned array treats `roi` as a half-closed interval: i.e. it should have shape np.diff(roi, axis=0)
+
+        Parameters
+        ----------
+        roi : array-like
+            2 x 3 array where the columns are the 3 dimensions in the target orientation, and the rows are the upper
+             and lower bounds of the ROI.
+        roi_mode : ROIMode or str
+            Default ROIMode.STACK
+        zoom_level : int
+        out : array-like or None
+            Anything with array-like __setitem__ handling (e.g. np.ndarray, np.memmap, h5py.File, z5py.File), to which
+            the results will be written. Must have the same shape in as the ROI does in scaled pixels. If None
+            (default), will create a new np.ndarray.
+
+        Returns
+        -------
+        array-like
+        """
+        roi_tgt = self.roi_to_scaled(roi, roi_mode, zoom_level)
+        roi_src = self._reorient_roi_tgt_to_src(roi_tgt)
+        tile_indices, inner_slicing_src = self._roi_to_tiles(roi_src, zoom_level)
+
+        if out is None:
+            out = np.zeros(np.diff(roi_tgt, axis=0).squeeze(), dtype=np.uint8)
+
+        return self._assemble_tiles(tile_indices, inner_slicing_src, out)
+
+    def get_project_space(self, roi, zoom_level=0, out=None):
+        """
+        Equivalent to `get` method with roi_mode=ROIMode.PROJECT
+        """
+        return self.get(roi, ROIMode.PROJECT, zoom_level, out)
+
+    def get_stack_space(self, roi, zoom_level=0, out=None):
+        """
+        Equivalent to `get` method with roi_mode=ROIMode.STACK
+        """
+        return self.get(roi, ROIMode.STACK, zoom_level, out)
+
+    def get_scaled_space(self, roi, zoom_level=0, out=None):
+        """
+        Equivalent to `get` method with roi_mode=ROIMode.SCALED
+        """
+        return self.get(roi, ROIMode.SCALED, zoom_level, out)
+
+    def set_fastest_mirror(self, reps=1, normalise_by_tile_size=True):
+        """
+        Set the ImageFetcher to use the fastest accessible mirror.
+
+        Parameters
+        ----------
+        reps : int
+            How many times to fetch the canary tile, for robustness
+        normalise_by_tile_size : bool
+            Whether to normalise the fetch time by the tile size used by this mirror (to get per-pixel response time)
+        """
+        self.mirror = self.stack.get_fastest_mirror(self.timeout, reps, normalise_by_tile_size)
+
+    @classmethod
+    def from_stack_info(cls, stack_info, *args, **kwargs):
+        """
+
+        Parameters
+        ----------
+        stack_info : dict
+        args, kwargs
+            See __init__ for arguments beyond stack
+
+        Returns
+        -------
+        ImageFetcher
+        """
+        return cls(ProjectStack.from_stack_info(stack_info), *args, **kwargs)
+
+    @classmethod
+    def from_catmaid(cls, catmaid, stack_id, *args, **kwargs):
+        """
+
+        Parameters
+        ----------
+        catmaid : catpy.AbstractCatmaidClient
+        stack_id : int
+        args, kwargs
+            See __init__ for arguments beyond stack
+
+        Returns
+        -------
+        ImageFetcher
+        """
+        stack_info = catmaid.get((catmaid.project_id, 'stack', stack_id, 'info'))
+        return cls.from_stack_info(stack_info, *args, **kwargs)
+
+
+class DummyResponse(object):
+    def __init__(self, array):
+        self.array = array
+
+
+def as_future_response(array):
+    return as_future(DummyResponse(array))
+
+
+class ThreadedImageFetcher(ImageFetcher):
+    def __init__(
+        self, stack, output_orientation=DEFAULT_3D_ORIENTATION, preferred_mirror=None, timeout=1,
+        cache_items=DEFAULT_CACHE_ITEMS, cache_bytes=DEFAULT_CACHE_BYTES,
+        broken_slice_handling=DEFAULT_BROKEN_SLICE_HANDLING, cval=0, threads=THREADS
+    ):
+        """
+        Note: for small numbers of tiles on fast internet connection, ImageFetcher may be faster
+
+        Parameters
+        ----------
+        stack : Stack
+        output_orientation : str or Orientation3D
+            default Orientation3D.ZYX
+        preferred_mirror : int or str or StackMirror or None
+            default None
+        timeout : float
+            default 1
+        cache_items : int or None
+            default 10
+        cache_bytes : int or None
+            default None
+        broken_slice_handling : str or BrokenSliceHandling
+            default BrokenSliceHandling.FILL
+        cval : int
+            default 0
+        threads : int
+            default 10
+        """
+        super(ThreadedImageFetcher, self).__init__(
+            stack, output_orientation, preferred_mirror, timeout,
+            cache_items, cache_bytes,
+            broken_slice_handling, cval
+        )
+        self._session = FuturesSession(session=self._session, max_workers=threads)
+
+    def _get_tile(self, tile_index):
+        """
+        Get the tile from the cache, handle broken slices, or fetch.
+
+        Parameters
+        ----------
+        tile_index : TileIndex
+
+        Returns
+        -------
+        Future
+        """
+        try:
+            return as_future_response(self._tile_cache.get(tile_index))
+        except KeyError:
+            pass
+
+        if tile_index.depth in self.stack.broken_slices:
+            if self.broken_slice_handling == BrokenSliceHandling.FILL and self.cval is not None:
+                tile = np.empty((tile_index.width, tile_index.height))
+                tile.fill(self.cval)
+                return as_future_response(tile)
+            else:
+                raise NotImplementedError(
+                    "'fill' with a non-None cval is the only implemented broken slice handling mode"
+                )
+
+        return self._fetch(tile_index)
+
+    def _iter_tiles(self, tile_indices):
+        fetched_tiles = {self._get_tile(tile_index): tile_index for tile_index in tile_indices}
+        for tile_future in as_completed(fetched_tiles):
+            yield tile_future.result().array, fetched_tiles[tile_future]
+
+    def _fetch(self, tile_index):
+        """
+
+        Parameters
+        ----------
+        tile_index : TileIndex
+
+        Returns
+        -------
+        Future of np.ndarray in source orientation
+        """
+        url = self.mirror.generate_url(tile_index)
+        return self._session.get(url, timeout=self.timeout, background_callback=response_to_array_callback)

--- a/catpy/image.py
+++ b/catpy/image.py
@@ -845,6 +845,9 @@ class ImageFetcher(object):
         if roi_mode == ROIMode.PROJECT:
             if not isinstance(self.stack, ProjectStack):
                 raise ValueError("ImageFetcher's stack is not related to a project, cannot use ROIMode.PROJECT")
+            if self.stack.orientation.lower() != 'xy':
+                warn("Stack orientation differs from project: returned array's orientation will reflect"
+                     "stack orientation, not project orientation")
             roi_tgt = self.coord_trans.project_to_stack_array(roi_tgt, dims=self.target_orientation)
             roi_mode = ROIMode.STACK
 
@@ -868,6 +871,9 @@ class ImageFetcher(object):
                 - `roi` is given in project space
                 - `zoom_level` specifies the zoom level of returned data
                 - Returned array may overflow desired ROI by < 1 scaled pixel per side
+                - Data will be reoriented from stack space/orientation into the `target_orientation` without
+                  going via project space: as such, for stacks with orientation other than 'xy', the output
+                  data will not be in the same orientation as the project-spaced query.
             ROIMode.STACK ('stack'):
                 - Default option
                 - `roi` is given in unscaled stack space (i.e. pixels at zoom level 0)

--- a/catpy/image.py
+++ b/catpy/image.py
@@ -2,6 +2,7 @@
 
 from __future__ import division, unicode_literals
 
+import logging
 from io import BytesIO
 from collections import OrderedDict
 from timeit import timeit
@@ -20,6 +21,9 @@ import requests
 from requests_futures.sessions import FuturesSession
 
 from catpy import CoordinateTransformer
+
+
+logger = logging.getLogger()
 
 
 class DummyTqdm(object):
@@ -1041,6 +1045,7 @@ class ThreadedImageFetcher(ImageFetcher):
         return self._fetch(tile_index)
 
     def _iter_tiles(self, tile_indices):
+        logger.info('Queuing requests, may take a few seconds...')
         fetched_tiles = {self._get_tile(tile_index): tile_index for tile_index in tile_indices}
         for tile_future in as_completed(fetched_tiles):
             yield tile_future.result().array, fetched_tiles[tile_future]

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,7 +2,10 @@
 Usage
 =====
 
-To use catpy in a project::
+CatmaidClient
+=============
+
+The basic feature of catpy is a class for interacting with CATMAID's REST API::
 
     import catpy
 
@@ -30,9 +33,12 @@ To make it easier to include variables, you can pass an iterable of URL componen
     project_id = 1
     annotations = client.post([project_id, 'annotations', 'query'], data=query)
 
+CatmaidClientApplication
+========================
+
 To write your own class making use of the ``CatmaidClient``, we recommend subclassing the
 ``CatmaidClientApplication`` abstract base class. This wraps an existing ``CatmaidClient`` instance, and passes through
- calls to ``get``, ``post``, ``fetch``, ``base_url`` and ``project_id``, allowing easier
+calls to ``get``, ``post``, ``fetch``, ``base_url`` and ``project_id``, allowing easier
 composition of applications and minimising work if you want to change e.g. the project ID of all of the applications
 you're working with::
 
@@ -47,6 +53,12 @@ you're working with::
     annotation_fetcher = AnnotationFetcher(client)
     annotations = annotation_fetcher.fetch_annotations(42)
 
+``CatmaidClient`` and all ``CatmaidClientApplication``s are subclasses of ``AbstractCatmaidClient``,
+for type checking purposes.
+
+CoordinateTransformer
+=====================
+
 A common task requires transforming coordinates between project (real) and stack (pixel) space. A class is provided for
 this purpose::
 
@@ -56,3 +68,67 @@ this purpose::
     stack_coords = {'x': 150, 'y': 252, 'z': 2}
     project_coords = transformer.stack_to_project(stack_coords)
     stack_coords == transformer.project_to_stack(project_coords)
+
+N.B.: Stacks may not be oriented the same way as projects. In stack space, ``z`` is depth,
+``y`` is the vertical dimension, and ``x`` is the horizontal dimension of image tiles.
+
+Stack coordinates are unscaled (i.e. zoom level 0) by default. Stack coordinates can be scaled
+for different zoom levels like so::
+
+    scaled_coords = transformer.stack_to_scaled(stack_coords, tgt_zoom=-2, src_zoom=0)
+
+By switching the ``src_zoom`` and ``tgt_zoom`` arguments, this method is its own inverse.
+
+N.B.: projects dealing with multiple stacks at different anisotropies have a different concept
+of scale levels than a simple project-stack relationship, and so these scale levels may not match up
+with what you see in the CATMAID UI.
+
+CatmaidUrl
+==========
+
+This simple class handles reading and generating deep links to particular views in the CATMAID UI::
+
+    from catpy.client import CatmaidUrl
+
+    url_obj = CatmaidUrl.from_catmaid(client, x=20, y=30, z=40)
+    url_obj.stack_id = 5
+    url_obj.tool = 'tracingtool'
+
+    url_str = str(url_obj)
+    url_str == https://YourCatmaidServer.org/catmaid/?pid=1&zp=40?yp=30?xp=20?tool=tracingtool?sid0=5&s0=0'
+
+    url_obj2 = CatmaidUrl.from_url(url_str)
+    url_obj2.stack_id == 5
+    url_obj2.open()  # opens default web browser at this URL
+
+ImageFetcher
+============
+
+This handles fetching ROIs of greyscale uint8 image data from some of CATMAID's common tile sources::
+
+    from catpy.image import ImageFetcher
+
+    fetcher = ImageFetcher.from_catmaid(client, stack_id=5)
+    fetcher.set_fastest_mirror()
+
+    shallow_top_left = [10, 200, 400]
+    deep_bottom_right = [15, 250, 450]
+    roi = [shallow_top_left, deep_bottom_right]
+
+    volume = fetcher.get_stack_space(roi)
+    volume.shape == (5, 50, 50)
+
+Image data can be written straight into an existing numpy array or h5py dataset using the ``out``
+kwarg of the get_* methods.
+
+Fetched tiles are LRU cached: the size of the cache can be controlled with the ``cache_items`` and
+``cache_bytes`` kwargs of the constructor.
+
+The ``output_orientation`` kwarg controls whether ROIs are re-ordered on the way in and data
+transposed on the way out, to allow ``ImageFetcher`` to be used easily with scripts relying on
+e.g. 'xyz' ordering. Note that the project-stack orientation is only used for conveniently converting
+project-spaced ROIs into stack-spaced ROIs: the returned data is transposed from stack space into
+the requested orientation, rather than going stack -> project -> requested.
+
+N.B.: There is also an experimental ``ThreadedImageFetcher`` for large ROIs over slow connections. For
+small ROIs and fast connections, the threading overhead may erase the benefits of parallelised downloads.

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,8 @@
-numpy==1.12.1
-requests==2.14.2
-six==1.10.0
+enum34==1.1.6; python_version < "3.4"
+futures==3.2.0; python_version < "3.3"
 networkx==1.11
+numpy==1.12.1
+Pillow==5.0.0
+requests==2.14.2
+requests-futures==0.9.7
+six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,13 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
+    'enum34>=1.1; python_version < "3.4"',
+    'futures>=3.2; python_version < "3.3"',
+    'networkx==1.11',
     'numpy>=1.12',
+    'Pillow>=5.0',
     'requests>=2.14',
+    'requests-futures>=0.9',
     'six>=1.10'
 ]
 
@@ -22,6 +27,7 @@ setup_requirements = [
 
 test_requirements = [
     'pytest>=3',
+    "mock==2.0.0; python_version < '3.6'"
 ]
 
 if sys.version_info < (3, 6):

--- a/tests/test_catmaid_client_application.py
+++ b/tests/test_catmaid_client_application.py
@@ -34,16 +34,21 @@ def test_property_passthrough(catmaid_mock, ConcreteApp):
     assert app.base_url == catmaid_mock.base_url == BASE_URL
 
 
-def test_method_passthrough(catmaid_mock, ConcreteApp):
+def test_get_post_call_fetch(catmaid_mock, ConcreteApp):
+    app = ConcreteApp(catmaid_mock)
+    rel_url = 'potato'
+
+    app.get(rel_url, params=None, raw=False)
+    catmaid_mock.fetch.assert_called_with(rel_url, method='GET', data=None, raw=False)
+
+    app.post(rel_url, data=None, raw=False)
+    catmaid_mock.fetch.assert_called_with(rel_url, method='POST', data=None, raw=False)
+
+
+def test_fetch_passthrough(catmaid_mock, ConcreteApp):
     app = ConcreteApp(catmaid_mock)
     args = (1, 2)
     kwargs = {'a': 1}
-
-    app.get(*args, **kwargs)
-    catmaid_mock.get.assert_called_with(*args, **kwargs)
-
-    app.post(*args, **kwargs)
-    catmaid_mock.post.assert_called_with(*args, **kwargs)
 
     app.fetch(*args, **kwargs)
     catmaid_mock.fetch.assert_called_with(*args, **kwargs)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -719,4 +719,4 @@ def test_imagefetcher_fetch(min_fetcher):
 def test_imagefetcher_get_wrappers(min_fetcher, space):
     min_fetcher.get = mock.Mock()
     getattr(min_fetcher, 'get_{}_space'.format(space.value))('roi', 'zoom_level')
-    min_fetcher.get.assert_called_with('roi', space, 'zoom_level')
+    min_fetcher.get.assert_called_with('roi', space, 'zoom_level', None)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -504,6 +504,23 @@ def test_imagefetcher_set_mirror_title_warns_too_many(min_fetcher):
     assert min_fetcher._mirror == min_fetcher.stack.mirrors[0]
 
 
+def test_imagefetcher_get_auth_default(min_fetcher):
+    min_fetcher.mirror = min_fetcher.stack.mirrors[0]
+    assert min_fetcher._session.auth is None
+
+
+def test_imagefetcher_get_auth_from_mirror(min_fetcher):
+    min_fetcher.stack.mirrors[0].auth = ('name', 'pass')
+    min_fetcher.mirror = min_fetcher.stack.mirrors[0]
+    assert min_fetcher._session.auth == ('name', 'pass')
+
+
+def test_imagefetcher_get_auth_fallback(min_fetcher):
+    min_fetcher.auth = ('name', 'pass')
+    min_fetcher.mirror = min_fetcher.stack.mirrors[0]
+    assert min_fetcher._session.auth == ('name', 'pass')
+
+
 def test_imagefetcher_clear_cache(min_fetcher):
     min_fetcher._tile_cache.clear = mock.Mock()
     min_fetcher.clear_cache()

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,0 +1,722 @@
+from itertools import cycle, chain
+
+import pytest
+import numpy as np
+import requests
+from PIL import Image
+from io import BytesIO
+from concurrent.futures import Future
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+from catpy.image import (
+    TileIndex, StackMirror, TileSourceType, TileCache,
+    format_urls, is_valid_format_url, response_to_array,
+    as_future, fill_tiled_cuboid, dict_subtract, Stack, ImageFetcher, ROIMode, ProjectStack, ThreadedImageFetcher,
+    DummyResponse)
+
+IMAGE_BASE = 'http://not-catmaid.org/'
+TILE_SOURCE_TYPE = TileSourceType.FILE_BASED
+FORMAT_URL = format_urls[TILE_SOURCE_TYPE]
+
+IMAGE_MODES = [
+    'L',  # 8-bit uint greyscale pixels
+    'RGB',  # 3x8-bit
+    'RGBa',  # 3x8-bit with premultiplied alpha
+    'RGBA',  # 4x8-bit (transparency mask)
+    'CMYK',  # 4x8-bit
+]
+
+
+@pytest.fixture()
+def row_maker():
+    """Generate a list of numbers from 1 to 254 inclusive, wrapping around"""
+    def maker(length, start=1):
+        if not 0 < start < 255:
+            raise ValueError('Start must be between 0 and 254 inclusive')
+        it = chain(range(start, 255), cycle(range(1, 255)))
+        out = []
+        while len(out) < length:
+            out.append(next(it))
+
+        return out
+
+    return maker
+
+
+@pytest.fixture
+def gradient_h(row_maker):
+    return np.array([row_maker(254)] * 128, dtype=np.uint8)
+
+
+@pytest.fixture
+def vol_maker(row_maker):
+    def maker(shape, x_offset=0):
+        while x_offset >= 254:
+            x_offset -= 254
+        return np.array([[row_maker(shape[2], x_offset + 1)] * shape[1]] * shape[0], dtype=np.uint8)
+    return maker
+
+
+@pytest.mark.parametrize('x_offset,shape,expected_final', [
+    (0, (1, 1, 1), 1),
+    (1, (1, 1, 1), 2),
+    (0, (10, 10, 10), 10),
+    (0, (1, 1, 300), 46),
+    (1, (1, 1, 300), 47),
+])
+def test_vol_maker(vol_maker, x_offset, shape, expected_final):
+    volume = vol_maker(shape, x_offset)
+    assert volume.shape == shape
+    assert volume[0, 0, 0] == x_offset + 1  # does not check large-offset
+    assert volume[-1, -1, -1] == expected_final
+
+
+def make_response_mock(content_arr, mode='L', format='png'):
+    response = mock.Mock(spec=requests.Response)
+    response.headers = {'Content-Type': 'image/' + format}
+    im = Image.fromarray(content_arr)
+    converted_im = im.convert(mode)
+
+    buffer = BytesIO()
+    converted_im.save(buffer, format)
+    buffer.seek(0)
+    response.content = buffer.read()
+
+    return response
+
+
+##########################
+# Utility function tests #
+##########################
+
+@pytest.mark.parametrize('mode', ['L', 'RGB', 'RGBA'])
+def test_response_to_array_png(gradient_h, mode):
+    response_mock = make_response_mock(gradient_h, mode, 'png')
+    returned_arr = response_to_array(response_mock)
+
+    assert np.allclose(gradient_h, returned_arr)
+
+
+@pytest.mark.parametrize('mode', ['L', 'RGB'])
+def test_response_to_array_jpeg(gradient_h, mode):
+    response_mock = make_response_mock(gradient_h, mode, 'jpeg')
+    returned_arr = response_to_array(response_mock)
+
+    # jpeg compression means exact matching is not possible
+    assert gradient_h.shape == returned_arr.shape
+    # assert np.allclose(gradient_h.ptp(), returned_arr.ptp())
+
+
+@pytest.mark.parametrize('tile_source_type,format_url', format_urls.items())
+def test_predefined_format_urls_are_valid(tile_source_type, format_url):
+    assert is_valid_format_url(format_url), 'URL for {} is invalid'.format(tile_source_type)
+
+
+def test_as_future_for_not_future():
+    item = 'item'
+
+    not_future_as_future = as_future(item)
+    assert isinstance(not_future_as_future, Future)
+    assert not_future_as_future.result() == item
+
+
+def test_as_future_for_future():
+    item = 'item'
+    future = Future()
+    future.set_result(item)
+
+    future_as_future = as_future(future)
+    assert isinstance(future_as_future, Future)
+    assert future_as_future.result() == item
+
+
+def test_fill_tiled_cuboid():
+    kwargs = {'zoom_level': 1, 'height': 2, 'width': 3}
+
+    min_tile = TileIndex(1, 2, 3, **kwargs)
+    max_tile = TileIndex(2, 4, 3, **kwargs)
+
+    results = fill_tiled_cuboid(min_tile, max_tile)
+
+    expected_results = {
+        TileIndex(1, 2, 3, **kwargs),
+        TileIndex(2, 2, 3, **kwargs),
+        TileIndex(1, 3, 3, **kwargs),
+        TileIndex(2, 3, 3, **kwargs),
+        TileIndex(1, 4, 3, **kwargs),
+        TileIndex(2, 4, 3, **kwargs)
+    }
+
+    assert results == expected_results
+
+
+def test_fill_tiled_cuboid_raises():
+    min_tile = TileIndex(1, 2, 3, 1, 2, 3)
+    max_tile = TileIndex(2, 4, 3, 4, 5, 6)
+
+    with pytest.raises(ValueError):
+        fill_tiled_cuboid(min_tile, max_tile)
+
+
+def test_dict_subtract_mismatched_keys():
+    d1 = {'a': 1, 'b': 2}
+    d2 = {'a': 5, 'c': 10}
+
+    with pytest.raises(ValueError):
+        dict_subtract(d1, d2)
+
+
+def test_dict_subtract():
+    d1 = {'a': 1, 'b': 2}
+    d2 = {'a': 5, 'b': 10}
+
+    result = dict_subtract(d1, d2)
+    assert result == {'a': -4, 'b': -8}
+
+
+###################
+# TileIndex tests #
+###################
+
+def test_tile_index_coords():
+    idx = TileIndex(5, 2, 1, None, 10, 20)
+    result = idx.coords
+
+    expected_result = {
+        'z': 5,
+        'y': 20,
+        'x': 20
+    }
+
+    assert result == expected_result
+
+
+@pytest.mark.parametrize('name', ['zoom_level', 'height', 'width'])
+def test_tile_index_comparable(name):
+    kwargs = {'zoom_level': 1, 'height': 10, 'width': 20}
+    idx1 = TileIndex(1, 2, 3, **kwargs)
+    idx2 = TileIndex(4, 5, 6, **kwargs)
+
+    assert idx1.is_comparable(idx2)
+
+    kwargs[name] = kwargs[name]*2
+    idx3 = TileIndex(7, 8, 9, **kwargs)
+
+    assert not idx1.is_comparable(idx3)
+
+
+def test_tile_index_url_kwargs():
+    idx = TileIndex(1, 2, 3, 4, 5, 6)
+    d = idx.url_kwargs
+    for key in ('depth', 'row', 'col', 'zoom_level'):
+        assert key in d
+
+
+#####################
+# StackMirror tests #
+#####################
+
+def test_stackmirror_corrects_image_base():
+    other_args = (1, 1, 1, 'png')
+    mirror_slash = StackMirror(IMAGE_BASE, *other_args)
+    mirror_no_slash = StackMirror(IMAGE_BASE[:-1], *other_args)
+
+    assert mirror_slash.image_base == mirror_no_slash.image_base == IMAGE_BASE
+
+
+def test_stackmirror_corrects_file_extension():
+    other_args = (IMAGE_BASE, 1, 1, 1)
+    mirror_dot = StackMirror(*other_args, file_extension='.png')
+    mirror_no_dot = StackMirror(*other_args, file_extension='png')
+
+    assert mirror_dot.file_extension == mirror_no_dot.file_extension == 'png'
+
+
+@pytest.mark.parametrize('tile_source_type', list(TileSourceType))
+def test_stackmirror_formats_url(tile_source_type):
+    mirror = StackMirror(IMAGE_BASE, 256, 256, tile_source_type, 'png')
+    tile_idx = TileIndex(0, 0, 0, 0, 256, 256)
+
+    response = mirror.generate_url(tile_idx)
+    assert not set('{}').issubset(response)
+
+
+def test_stackmirror_raises_on_incompatible_tile_index():
+    mirror = StackMirror(IMAGE_BASE, 512, 512, TILE_SOURCE_TYPE, 'png')
+    tile_idx = TileIndex(0, 0, 0, 0, 256, 256)
+
+    with pytest.raises(ValueError):
+        mirror.generate_url(tile_idx)
+
+
+def test_stackmirror_get_tile_index():
+    tile_side = 100
+    mirror = StackMirror(IMAGE_BASE, tile_side, tile_side, TILE_SOURCE_TYPE, 'png')
+    tile_idx_kwargs = {'zoom_level': 0, 'height': tile_side, 'width': tile_side}
+
+    # trivial case
+    coords = {'x': 0, 'y': 0, 'z': 0}
+    idx, offset = mirror.get_tile_index(coords)
+    assert idx == TileIndex(0, 0, 0, **tile_idx_kwargs)
+    assert offset == {'x': 0, 'y': 0, 'z': 0}
+
+    # test offset
+    coords = {'x': 50, 'y': 50, 'z': 0}
+    idx, offset = mirror.get_tile_index(coords)
+    assert idx == TileIndex(0, 0, 0, **tile_idx_kwargs)
+    assert offset == {'x': 50, 'y': 50, 'z': 0}
+
+    # test tile idx
+    coords = {'x': tile_side, 'y': tile_side, 'z': 1}
+    idx, offset = mirror.get_tile_index(coords)
+    assert idx == TileIndex(1, 1, 1, **tile_idx_kwargs)
+    assert offset == {'x': 0, 'y': 0, 'z': 0}
+
+    # test row/col correctness
+    coords = {'x': tile_side, 'y': 0, 'z': 0}
+    idx, offset = mirror.get_tile_index(coords)
+    assert idx == TileIndex(depth=0, row=0, col=1, **tile_idx_kwargs)
+    assert offset == {'x': 0, 'y': 0, 'z': 0}
+
+
+###############
+# Stack tests #
+###############
+
+def test_stack_sets_broken_slices_canary():
+    stack = Stack(None)
+
+    assert len(stack.broken_slices) == 0
+    assert stack.canary_location == {'x': 0, 'y': 0, 'z': 0}
+
+
+def test_stack_fastest_mirror_calls_get():
+    stack = Stack(None)
+    stack.mirrors = [StackMirror(IMAGE_BASE, 512, 512, TILE_SOURCE_TYPE, 'png')] * 3
+
+    with mock.patch('requests.get') as mock_get:
+        stack.get_fastest_mirror()
+
+    assert mock_get.call_count == 3
+
+
+def test_stack_fastest_mirror_raises():
+    stack = Stack(None)
+    stack.mirrors = [StackMirror(IMAGE_BASE, 512, 512, TILE_SOURCE_TYPE, 'png')] * 3
+
+    with pytest.raises(ValueError):
+        stack.get_fastest_mirror(timeout=0.01)
+
+
+@pytest.mark.xfail(reason="Mock timeit doesn't work", raises=ValueError)
+def test_stack_fastest_mirror_gets_fastest():
+    # todo
+    stack = Stack(None)
+    stack.mirrors = [
+        StackMirror(IMAGE_BASE + '2', 512, 512, TILE_SOURCE_TYPE, 'png'),
+        StackMirror(IMAGE_BASE + '1', 512, 512, TILE_SOURCE_TYPE, 'png'),
+        StackMirror(IMAGE_BASE + '3', 512, 512, TILE_SOURCE_TYPE, 'png')
+    ]
+
+    with mock.patch('timeit.timeit', side_effect=[2, 1, 3]):
+        m = stack.get_fastest_mirror()
+
+    assert m == stack.mirrors[1]
+
+
+###################
+# TileCache tests #
+###################
+
+def test_tilecache_can_push():
+    cache = TileCache(None, None)
+    key = 1
+    value = 1
+
+    assert len(cache) == 0
+
+    cache.push(key, value)
+    assert len(cache) == 1
+
+
+def test_tilecache_push_refreshes_old():
+    """Ensure that newly-pushed items get appended to the end, even if they already exist in the cache"""
+    cache = TileCache(None, None)
+    key = 1
+    value = 1
+
+    assert len(cache) == 0
+
+    cache.push(key, value)
+    cache.push(2, 2)
+    assert list(cache) == [1, 2]
+    cache.push(1, 1)
+    assert list(cache) == [2, 1]
+
+
+def test_tilecache_can_get():
+    cache = TileCache(None, None)
+    key = 1
+    value = 1
+
+    assert len(cache) == 0
+
+    cache.push(key, value)
+    assert len(cache) == 1
+
+    response = cache.get(key)
+    assert response == value
+
+
+def test_tilecache_can_clear():
+    cache = TileCache(None, None)
+    key = 1
+    value = 1
+
+    assert len(cache) == 0
+
+    cache.push(key, value)
+    assert len(cache) == 1
+
+    cache.clear()
+    assert len(cache) == 0
+
+
+def test_tilecache_can_constrain_len():
+    cache = TileCache(3, None)
+
+    for key in range(3):
+        cache.push(key, str(key))
+    assert set(cache) == {0, 1, 2}
+
+    cache.push(3, '3')
+    assert set(cache) == {1, 2, 3}
+
+
+def test_tilecache_can_constrain_bytes():
+    arr = np.ones((10, 10))
+    nbytes = arr.nbytes
+
+    cache = TileCache(None, int(nbytes*3.5))
+
+    for key in range(3):
+        cache.push(key, arr)
+    assert set(cache) == {0, 1, 2}
+
+    cache.push(3, arr)
+    assert set(cache) == {1, 2, 3}
+
+
+######################
+# ImageFetcher tests #
+######################
+
+
+def test_imagefetcher_can_instantiate():
+    ImageFetcher(Stack(None))
+
+
+def mirror_generator(count=5):
+    for idx in range(count):
+        yield StackMirror(
+            IMAGE_BASE + str(idx), 100 + idx, 200 + idx, TILE_SOURCE_TYPE,
+            'png', title='title' + str(idx), position=idx*2
+        )
+
+
+@pytest.fixture
+def min_fetcher():
+    stack = Stack(None)
+    stack.mirrors.extend(mirror_generator())
+
+    return ImageFetcher(stack)
+
+
+def test_imagefetcher_mirror_fallback_warning(min_fetcher):
+    min_fetcher._mirror = None
+    with pytest.warns(UserWarning, match='title0'):
+        min_fetcher.mirror
+
+
+def test_imagefetcher_set_mirror_none(min_fetcher):
+    min_fetcher.mirror = None
+
+    with pytest.warns(UserWarning, match='title0'):
+        min_fetcher.mirror
+
+    assert min_fetcher._mirror is None
+
+
+def test_imagefetcher_set_mirror_mirror(min_fetcher):
+    min_fetcher.mirror = min_fetcher.stack.mirrors[1]
+    assert min_fetcher._mirror == min_fetcher.stack.mirrors[1]
+
+
+def test_imagefetcher_set_mirror_mirror_raises(min_fetcher):
+    mirror = min_fetcher.stack.mirrors.pop()
+    min_fetcher.stack.mirrors = []
+    with pytest.raises(ValueError):
+        min_fetcher.mirror = mirror
+
+
+def test_imagefetcher_set_mirror_int(min_fetcher):
+    min_fetcher.mirror = 2
+    assert min_fetcher._mirror == min_fetcher.stack.mirrors[1]
+
+
+def test_imagefetcher_set_mirror_int_as_str(min_fetcher):
+    min_fetcher.mirror = '2'
+    assert min_fetcher._mirror == min_fetcher.stack.mirrors[1]
+
+
+def test_imagefetcher_set_mirror_position_warns_no_match(min_fetcher):
+    with pytest.warns(UserWarning, match='does not exist'):
+        min_fetcher.mirror = 1000
+    assert min_fetcher._mirror is None
+
+
+def test_imagefetcher_set_mirror_position_warns_too_many(min_fetcher):
+    min_fetcher.stack.mirrors.append(StackMirror(IMAGE_BASE, 1, 1, TILE_SOURCE_TYPE, 'png', 'title5', 0))
+    with pytest.warns(UserWarning, match='ore than one'):
+        min_fetcher.mirror = 0
+    assert min_fetcher._mirror == min_fetcher.stack.mirrors[0]
+
+
+def test_imagefetcher_set_mirror_title(min_fetcher):
+    min_fetcher.mirror = 'title2'
+    assert min_fetcher._mirror == min_fetcher.stack.mirrors[2]
+
+
+def test_imagefetcher_set_mirror_title_warns_no_match(min_fetcher):
+    with pytest.warns(UserWarning, match='does not exist'):
+        min_fetcher.mirror = 'not a title'
+    assert min_fetcher._mirror is None
+
+
+def test_imagefetcher_set_mirror_title_warns_too_many(min_fetcher):
+    min_fetcher.stack.mirrors.append(StackMirror(IMAGE_BASE, 1, 1, TILE_SOURCE_TYPE, 'png', 'title0', 10))
+    with pytest.warns(UserWarning, match='does not exist'):
+        min_fetcher.mirror = 'title0'
+    assert min_fetcher._mirror == min_fetcher.stack.mirrors[0]
+
+
+def test_imagefetcher_clear_cache(min_fetcher):
+    min_fetcher._tile_cache.clear = mock.Mock()
+    min_fetcher.clear_cache()
+    min_fetcher._tile_cache.clear.assert_called_once()
+
+
+def test_imagefetcher_map_dimensions(min_fetcher):
+    min_fetcher.source_orientation = 'zyx'
+    min_fetcher.target_orientation = 'xyz'
+
+    assert min_fetcher._map_dimensions() == (2, 1, 0)
+
+
+def test_imagefetcher_reorient(min_fetcher):
+    min_fetcher.source_orientation = 'zyx'
+    min_fetcher.target_orientation = 'xyz'
+    min_fetcher._dimension_mappings = min_fetcher._map_dimensions()
+    arr = np.ones((3, 4, 5))
+    assert min_fetcher._reorient_volume_src_to_tgt(arr).shape == (5, 4, 3)
+
+
+def test_imagefetcher_reorient_expands(min_fetcher):
+    min_fetcher.source_orientation = 'zyx'
+    min_fetcher.target_orientation = 'xyz'
+    min_fetcher._dimension_mappings = min_fetcher._map_dimensions()
+    arr = np.ones((3, 4))
+    assert min_fetcher._reorient_volume_src_to_tgt(arr).shape == (4, 3, 1)
+
+
+def test_imagefetcher_reorient_throws(min_fetcher):
+    arr = np.ones((3, 4, 5, 6))
+
+    with pytest.raises(ValueError):
+        min_fetcher._reorient_volume_src_to_tgt(arr)
+
+
+# drc=depth,row,col
+@pytest.mark.parametrize('roi,expected_drc,expected_yx_minmax', [
+    [[[0, 0, 0], [1, 1, 1]],      [(0, 0, 0)],            ((0, 0), (0, 0))],
+    [[[0, 0, 0], [2, 1, 1]],      [(0, 0, 0), (1, 0, 0)], ((0, 0), (0, 0))],
+    [[[0, 0, 0], [1, 51, 51]],    [(0, 0, 0)],            ((0, 50), (0, 50))],
+    [[[0, 20, 20], [1, 51, 51]],  [(0, 0, 0)],            ((20, 50), (20, 50))],
+    [[[0, 20, 20], [1, 151, 51]], [(0, 0, 0), (0, 1, 0)], ((20, 50), (20, 50))],
+])
+def test_imagefetcher_roi_to_tiles(min_fetcher, roi, expected_drc, expected_yx_minmax):
+    tile_side = 100
+    zoom_level = 0
+    mirror = StackMirror(IMAGE_BASE, tile_side, tile_side, TILE_SOURCE_TYPE, 'png')
+    min_fetcher.stack.mirrors = [mirror]
+    min_fetcher.mirror = mirror
+
+    (min_y, max_y), (min_x, max_x) = expected_yx_minmax
+    expected_bounds = {
+        'min': {
+            'z': 0,
+            'y': min_y,
+            'x': min_x,
+        },
+        'max': {
+            'z': 0,
+            'y': max_y,
+            'x': max_x,
+        },
+    }
+
+    expected_tiles = {TileIndex(*drc, zoom_level=zoom_level, height=tile_side, width=tile_side) for drc in expected_drc}
+
+    tiles, slicing = min_fetcher._roi_to_tiles(roi, zoom_level)
+
+    assert tiles == expected_tiles
+    assert slicing == expected_bounds
+
+
+@pytest.fixture
+def tile_gen(gradient_h):
+    def generator():
+        while True:
+            yield gradient_h.copy()
+    return generator()
+
+
+@pytest.fixture
+def tile_response_future_gen(tile_gen):
+    """Endlessly generate a Future containing a Response containing gradient_h as a PNG"""
+    def generator():
+        for arr in tile_gen:
+            future = Future()
+            future.set_result(DummyResponse(arr))
+            yield future
+
+    return generator()
+
+
+@pytest.fixture(params=[ImageFetcher, ThreadedImageFetcher])
+def realistic_fetcher(request, gradient_h, tile_gen, tile_response_future_gen):
+    tile_height, tile_width = gradient_h.shape
+    stack = ProjectStack(
+        dimension={'z': 100, 'y': 200, 'x': 300},
+        translation={'z': 10, 'y': 20, 'x': 30},
+        resolution={'z': 1, 'y': 2, 'x': 3},
+        orientation='xy'
+    )
+    mirror = StackMirror(IMAGE_BASE, tile_height, tile_width, TILE_SOURCE_TYPE, 'png', 'title', 0)
+    stack.mirrors.append(mirror)
+
+    fetcher = request.param(stack, preferred_mirror=0)
+
+    side_effect = tile_gen if request.param == ImageFetcher else tile_response_future_gen
+    fetcher._fetch = mock.Mock(side_effect=side_effect)
+
+    return fetcher
+
+
+@pytest.mark.parametrize('roi_mode,zoom_level,expected', [
+    [ROIMode.SCALED, 0,   [[0, 0, 0],       [10, 10, 10]]],
+    [ROIMode.STACK, 0,    [[0, 0, 0],       [10, 10, 10]]],
+    [ROIMode.STACK, -2,   [[0, 2, 2],       [10, 38, 38]]],
+    [ROIMode.STACK, 1,    [[0, 0, 0],       [10, 5, 5]]],
+    [ROIMode.PROJECT, 0,  [[-10, -10, -10], [0, -5, -6]]],
+    [ROIMode.PROJECT, -2, [[-10, -39, -40], [0, -21, -27]]],
+    [ROIMode.PROJECT, 1,  [[-10, -5, -5],   [0, -2, -3]]]
+])
+def test_imagefetcher_roi_to_scaled(realistic_fetcher, roi_mode, zoom_level, expected):
+    input_roi = np.array([[0.5, 0.5, 0.5], [9.5, 9.5, 9.5]])
+    result = realistic_fetcher.roi_to_scaled(input_roi, roi_mode, zoom_level)
+    assert np.allclose(result, np.array(expected, dtype=int))
+
+
+def test_imagefetcher_roi_to_scaled_raises(realistic_fetcher):
+    with pytest.raises(NotImplementedError):
+        realistic_fetcher.roi_to_scaled([[0, 0, 0], [1, 1, 1]], roi_mode=ROIMode.SCALED, zoom_level=0.5)
+
+
+@pytest.mark.parametrize('roi,expected_fetches', [
+    ([[0, 0, 0], [1, 20, 20]], 1),
+    ([[0, 0, 0], [2, 20, 20]], 2),
+    ([[0, 10, 10], [1, 20, 30]], 1),
+    ([[0, 10, 10], [1, 20, 300]], 2),
+    ([[0, 0, 0], [1, 20, 300]], 2),
+    ([[0, 0, 0], [1, 200, 300]], 4),
+    ([[10, 10, 10], [13, 200, 300]], 12),
+])
+def test_imagefetcher_get(realistic_fetcher, vol_maker, roi, expected_fetches):
+    zoom_level = 0
+    roi_mode = ROIMode.SCALED
+
+    realistic_fetcher.stack.broken_slices.add(100)
+
+    roi = np.asarray(roi)
+
+    expected = vol_maker(np.diff(roi, axis=0).squeeze(), roi[0, -1])
+
+    output = realistic_fetcher.get(roi, roi_mode, zoom_level)
+
+    assert output.shape == expected.shape
+    assert np.allclose(expected, output)
+    assert realistic_fetcher._fetch.call_count == expected_fetches
+
+
+def test_imagefetcher_get_into_array(realistic_fetcher, vol_maker):
+    zoom_level = 0
+    roi_mode = ROIMode.SCALED
+    roi = np.array([[10, 10, 10], [13, 200, 300]])
+    shape = np.diff(roi, axis=0).squeeze()
+    out = np.empty(shape)
+    expected = vol_maker(shape, roi[0, -1])
+
+    out2 = realistic_fetcher.get(roi, roi_mode, zoom_level, out)
+
+    assert out is out2
+    assert out2.shape == expected.shape
+    assert np.allclose(expected, out2)
+    assert realistic_fetcher._fetch.call_count == 12
+
+
+def test_imagefetcher_get_tile_from_cache(realistic_fetcher, tile_gen):
+    cached = next(tile_gen)
+    height, width = cached.shape
+    tile_index = TileIndex(0, 0, 0, 0, height, width)
+
+    realistic_fetcher._tile_cache.push(tile_index, cached)
+    out = realistic_fetcher.get([[0, 0, 0], [1, height, width]], ROIMode.SCALED, 0)
+    realistic_fetcher._fetch.assert_not_called()
+    assert np.allclose(out.squeeze(), cached)
+
+
+def test_imagefetcher_get_tile_from_broken_slice(realistic_fetcher, tile_gen):
+    height, width = next(tile_gen).shape
+    realistic_fetcher.stack.broken_slices.add(0)
+    shape = (1, height, width)
+    out = realistic_fetcher.get([[0, 0, 0], shape], ROIMode.SCALED, 0)
+    expected = np.zeros(shape)
+    assert np.allclose(out, expected)
+    realistic_fetcher._fetch.assert_not_called()
+
+
+def test_imagefetcher_get_tile_from_fetch(min_fetcher):
+    idx = TileIndex(0, 0, 0, 0, 100, 100)
+    min_fetcher._fetch = mock.Mock()
+    min_fetcher._get_tile(idx)
+    min_fetcher._fetch.assert_called_with(idx)
+
+
+def test_imagefetcher_fetch(min_fetcher):
+    idx = TileIndex(0, 0, 0, 0, 100, 100)
+    min_fetcher._session.get = mock.Mock()
+    with mock.patch('catpy.image.response_to_array', mock.Mock()):
+        min_fetcher._fetch(idx)
+    min_fetcher._session.get.assert_called_once()
+
+
+@pytest.mark.parametrize('space', list(ROIMode))
+def test_imagefetcher_get_wrappers(min_fetcher, space):
+    min_fetcher.get = mock.Mock()
+    getattr(min_fetcher, 'get_{}_space'.format(space.value))('roi', 'zoom_level')
+    min_fetcher.get.assert_called_with('roi', space, 'zoom_level')

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -332,18 +332,18 @@ def test_stack_fastest_mirror_gets_fastest():
 # TileCache tests #
 ###################
 
-def test_tilecache_can_push():
+def test_tilecache_can_set():
     cache = TileCache(None, None)
     key = 1
     value = 1
 
     assert len(cache) == 0
 
-    cache.push(key, value)
+    cache[key] = value
     assert len(cache) == 1
 
 
-def test_tilecache_push_refreshes_old():
+def test_tilecache_set_refreshes_old():
     """Ensure that newly-pushed items get appended to the end, even if they already exist in the cache"""
     cache = TileCache(None, None)
     key = 1
@@ -351,10 +351,10 @@ def test_tilecache_push_refreshes_old():
 
     assert len(cache) == 0
 
-    cache.push(key, value)
-    cache.push(2, 2)
+    cache[key] = value
+    cache[2] = 2
     assert list(cache) == [1, 2]
-    cache.push(1, 1)
+    cache[1] = 1
     assert list(cache) == [2, 1]
 
 
@@ -365,11 +365,20 @@ def test_tilecache_can_get():
 
     assert len(cache) == 0
 
-    cache.push(key, value)
+    cache[key] = value
     assert len(cache) == 1
 
-    response = cache.get(key)
+    response = cache[key]
     assert response == value
+
+
+def test_tilecache_lru():
+    cache = TileCache(None, None)
+    cache[1] = 1
+    cache[2] = 2
+    val = cache[1]
+    assert val == 1
+    assert list(cache) == [2, 1]
 
 
 def test_tilecache_can_clear():
@@ -379,7 +388,7 @@ def test_tilecache_can_clear():
 
     assert len(cache) == 0
 
-    cache.push(key, value)
+    cache[key] = value
     assert len(cache) == 1
 
     cache.clear()
@@ -390,10 +399,10 @@ def test_tilecache_can_constrain_len():
     cache = TileCache(3, None)
 
     for key in range(3):
-        cache.push(key, str(key))
+        cache[key] = str(key)
     assert set(cache) == {0, 1, 2}
 
-    cache.push(3, '3')
+    cache[3] = '3'
     assert set(cache) == {1, 2, 3}
 
 
@@ -404,10 +413,10 @@ def test_tilecache_can_constrain_bytes():
     cache = TileCache(None, int(nbytes*3.5))
 
     for key in range(3):
-        cache.push(key, arr)
+        cache[key] = arr
     assert set(cache) == {0, 1, 2}
 
-    cache.push(3, arr)
+    cache[3] = arr
     assert set(cache) == {1, 2, 3}
 
 
@@ -701,7 +710,7 @@ def test_imagefetcher_get_tile_from_cache(realistic_fetcher, tile_gen):
     height, width = cached.shape
     tile_index = TileIndex(0, 0, 0, 0, height, width)
 
-    realistic_fetcher._tile_cache.push(tile_index, cached)
+    realistic_fetcher._tile_cache[tile_index] = cached
     out = realistic_fetcher.get([[0, 0, 0], [1, height, width]], ROIMode.SCALED, 0)
     realistic_fetcher._fetch.assert_not_called()
     assert np.allclose(out.squeeze(), cached)

--- a/tests/test_utils/test_coordinate_transformer.py
+++ b/tests/test_utils/test_coordinate_transformer.py
@@ -1,0 +1,151 @@
+from __future__ import division, unicode_literals
+
+from itertools import permutations
+from random import Random
+
+import numpy as np
+import pytest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from catpy.client import CoordinateTransformer
+
+
+COUNT = 20
+SEED = 1
+
+DIMS = 'xyz'
+DIRECTIONS = 'stack_to_project', 'project_to_stack'
+
+
+@pytest.fixture
+def default_res():
+    return {
+        'x': 1.0,
+        'y': 2.0,
+        'z': 3.0
+    }
+
+
+@pytest.fixture
+def default_trans():
+    return {
+        'x': 10.0,
+        'y': 20.0,
+        'z': 30.0
+    }
+
+
+@pytest.fixture
+def coordinate_generator():
+    """Return a generator which returns `count` randomly-generated coordinates in the range [-1000, 1000], in a mixture
+    of floats and ints"""
+    def wrapped(count=COUNT, seed=SEED):
+        twister = Random(seed)
+
+        def rand(is_int=False):
+            n = (twister.random() - 0.5) * 1000
+            return n if not is_int else int(n)
+
+        for _ in range(count):
+            is_int = twister.random() > 0.5
+            yield {dim: rand(is_int) for dim in DIMS}
+
+    return wrapped
+
+
+@pytest.fixture
+def catmaid_mock(default_res, default_trans):
+    catmaid = mock.Mock()
+    stack_info = {
+        'resolution': default_res,
+        'translation': default_trans
+    }
+    catmaid.configure_mock(**{'get.return_value': stack_info})
+    return catmaid
+
+
+@pytest.fixture
+def default_obj(default_res, default_trans):
+    return CoordinateTransformer(default_res, default_trans)
+
+
+@pytest.mark.parametrize('res_fixture', [default_res, lambda: None])
+@pytest.mark.parametrize('trans_fixture', [default_trans, lambda: None])
+def test_instantiate(res_fixture, trans_fixture):
+    assert CoordinateTransformer(res_fixture(), trans_fixture())
+
+
+def test_from_catmaid(default_obj, catmaid_mock):
+    assert CoordinateTransformer.from_catmaid(catmaid_mock, None) == default_obj
+
+
+@pytest.mark.parametrize('dim', DIMS)
+def test_project_to_stack_coord(dim, default_obj, default_res, default_trans):
+    project_coord = 10
+
+    expected_response = (project_coord - default_trans[dim]) / default_res[dim]
+    response = default_obj.project_to_stack_coord(dim, project_coord)
+
+    assert response == expected_response
+
+
+@pytest.mark.parametrize('dim', DIMS)
+def test_stack_to_project_coord(dim, default_obj, default_res, default_trans):
+    stack_coord = 10
+
+    expected_response = (stack_coord * default_res[dim]) + default_trans[dim]
+    response = default_obj.stack_to_project_coord(dim, stack_coord)
+
+    assert response == expected_response
+
+
+@pytest.mark.parametrize('direction', DIRECTIONS)
+def test_stack_to_project_and_project_to_stack(coordinate_generator, default_obj, direction):
+    for coords in coordinate_generator():
+        expected_response = {
+            dim: getattr(default_obj, direction + '_coord')(dim, coord) for dim, coord in coords.items()
+        }
+        actual_response = getattr(default_obj, direction)(coords)
+
+        assert expected_response == actual_response
+
+
+def get_expected_array_response(coordinate_transformer, direction, coords_list, dims=DIMS):
+    """
+
+    Parameters
+    ----------
+    coordinate_transformer : CoordinateTransformer
+    direction : str
+        'project_to_stack' or 'stack_to_project'
+    coords_list : list of dict
+        dicts are of form {'x': number, 'y': number, 'z': number}
+    dims : iterable
+        dimension order, default 'xyz'
+
+    Returns
+    -------
+    np.array
+    """
+    output = []
+    for coords in coords_list:
+        transformed = getattr(coordinate_transformer, direction)(coords)
+        output.append([transformed[dim] for dim in dims])
+
+    return np.array(output)
+
+
+@pytest.mark.parametrize('dims', permutations('xyz'))
+@pytest.mark.parametrize('direction', DIRECTIONS)
+def test_arrays(coordinate_generator, default_obj, direction, dims):
+    coords_list = list(coordinate_generator())
+    coords_array = np.array([[coords[dim] for dim in dims] for coords in coords_list])
+
+    expected_response = get_expected_array_response(default_obj, direction, coords_list, dims)
+    actual_response = getattr(default_obj, direction + '_array')(coords_array, dims=dims)
+
+    assert np.allclose(actual_response, expected_response)

--- a/tests/test_utils/test_url_builder.py
+++ b/tests/test_utils/test_url_builder.py
@@ -1,0 +1,141 @@
+import pytest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from catpy.client import CatmaidUrl
+
+BASE_URL = 'https://not.catmaid.org/'
+PROJECT_ID = 1
+STACK_GROUP_ID = 1
+STACK_ID = 2
+SCALE = 3.0
+X = 10.0
+Y = 20.0
+Z = 30.0
+TOOL = 'tracingtool'
+ACTIVE_SKELETON_ID = 100
+ACTIVE_NODE_ID = 200
+
+
+@pytest.fixture
+def catmaid_mock():
+    return mock.Mock(base_url=BASE_URL, project_id=PROJECT_ID)
+
+
+@pytest.fixture
+def default_kwargs():
+    return {
+        'base_url': BASE_URL,
+        'project_id': PROJECT_ID,
+        'stack_group_id': STACK_GROUP_ID,
+        'stack_id': STACK_ID,
+        'scale': SCALE,
+        'x': X,
+        'y': Y,
+        'z': Z,
+        'tool': TOOL,
+        'active_skeleton_id': ACTIVE_SKELETON_ID,
+        'active_node_id': ACTIVE_NODE_ID
+
+    }
+
+
+@pytest.fixture
+def default_url(default_kwargs):
+    return CatmaidUrl(**default_kwargs)
+
+
+def test_instantiate(default_url):
+    """Test that the object can be instantiated"""
+    catmaid_url = CatmaidUrl(
+        BASE_URL, PROJECT_ID, STACK_GROUP_ID, STACK_ID, SCALE, X, Y, Z, TOOL, ACTIVE_SKELETON_ID, ACTIVE_NODE_ID
+    )
+    assert str(catmaid_url) == str(default_url)
+
+
+def test_str(default_kwargs, default_url):
+    """Test that __str__ behaves as expected"""
+    expected_response = (
+        '{base_url}?pid={project_id}' +
+        '&xp={x}&yp={y}&zp={z}' +
+        '&tool={tool}&active_node_id={active_node_id}&active_skeleton_id={active_skeleton_id}' +
+        '&sg={stack_group_id}&sgs={scale}' +
+        '&sid0={stack_id}&s0={scale}'
+    ).format(**default_kwargs)
+    assert str(default_url) == expected_response
+
+
+def test_ignores_unfilled_coords(default_kwargs):
+    """Test that if any of the 3 coords are missing, all are ignored, and a warning is raised"""
+    kwargs = dict(default_kwargs)
+    del kwargs['x']
+    with pytest.warns(UserWarning, match='ignoring'):
+        url_str = str(CatmaidUrl(**kwargs))
+    for dim in 'xyz':
+        assert dim + 'p' not in url_str
+
+
+def test_add_stacks(default_url):
+    """Test that new stacks can be added after instantiation"""
+    new_stack_id = 5
+    new_stack_scale = -1
+
+    default_url.add_stack(new_stack_id, new_stack_scale)
+    assert 'sid1={}&s1={}'.format(new_stack_id, new_stack_scale) in str(default_url)
+
+
+def test_add_stacks_fills_scale(default_url):
+    """Test that a stack's scale is populated with a default when not explicitly given"""
+    new_stack_id = 5
+
+    default_url.add_stack(new_stack_id)
+    assert 'sid1={}&s1={}'.format(new_stack_id, SCALE) in str(default_url)
+
+
+def test_set_stack_group(default_url):
+    """Test that a stack group can be set after instantiation"""
+    new_stack_group = 5
+    new_stack_group_scale = -1
+
+    default_url.set_stack_group(new_stack_group, new_stack_group_scale)
+    assert 'sg={}&sgs={}'.format(new_stack_group, new_stack_group_scale) in str(default_url)
+
+
+def test_set_stack_group_fills_scale(default_kwargs):
+    """Test that a stack group's scale is populated with a default when not explicitly given"""
+    new_stack_group = 5
+
+    kwargs = dict(default_kwargs)
+    del kwargs['stack_group_id']
+    catmaid_url = CatmaidUrl(**default_kwargs)
+    catmaid_url.set_stack_group(new_stack_group)
+
+    assert 'sg={}&sgs={}'.format(new_stack_group, SCALE) in str(catmaid_url)
+
+
+def test_different_tool_ignores_active(default_kwargs):
+    """Test that tool-specific arguments are ignored when using a different tool"""
+    kwargs = dict(default_kwargs)
+    kwargs['tool'] = 'not_tracingtool'
+
+    url_str = str(CatmaidUrl(**kwargs))
+    assert 'active' not in url_str
+
+
+def test_from_catmaid(catmaid_mock, default_kwargs, default_url):
+    """Test that a CatmaidUrl object instantiated from a CatmaidClient-like object is the same as using args"""
+    kwargs = dict(default_kwargs)
+    del kwargs['base_url']
+    del kwargs['project_id']
+
+    catmaid_url = CatmaidUrl.from_catmaid(catmaid_mock, **kwargs)
+    assert str(catmaid_url) == str(default_url)
+
+
+def test_from_url(default_url):
+    """Test that a CatmaidUrl object instantiated using from_str is the same as using the args"""
+    from_str = CatmaidUrl.from_url(str(default_url))
+    assert str(default_url) == str(from_str)


### PR DESCRIPTION
Resolves #17

Image fetcher: 

> This allows users to fetch arbitrary regions of image data from a
variety of CATMAID tile sources. Integer zoom levels and indexing in
unscaled stack coordinates, scaled stack coordinates, and project
coordinates, in arbitrary dimension orders, are supported. Requests
are threaded for performance by default but can be run in serial.

URL builder implementation: https://github.com/catmaid/catpy/commit/644af0857a34313da73b651da0e745f4995a0358

Quite a lot in this, I forgot to merge the last PR.