### PR TITLE
Fix integer orientation bug

### DIFF
--- a/catpy/__init__.py
+++ b/catpy/__init__.py
@@ -10,3 +10,5 @@ __all__ = ['client']
 
 
 from catpy.client import CatmaidClient, CoordinateTransformer, CatmaidUrl  # noqa
+from catpy import image
+from catpy import export

--- a/catpy/__init__.py
+++ b/catpy/__init__.py
@@ -10,5 +10,5 @@ __all__ = ['client']
 
 
 from catpy.client import CatmaidClient, CoordinateTransformer, CatmaidUrl  # noqa
-from catpy import image
-from catpy import export
+from catpy import image  # noqa
+from catpy import export  # noqa

--- a/catpy/image.py
+++ b/catpy/image.py
@@ -436,7 +436,8 @@ class ProjectStack(Stack):
         """
         stack = cls(
             stack_info['dimension'], stack_info['translation'], stack_info['resolution'],
-            cls.orientation_choices[stack_info['orientation']], stack_info['broken_slices'], stack_info['canary_location']
+            cls.orientation_choices[stack_info['orientation']], stack_info['broken_slices'],
+            stack_info['canary_location']
         )
         mirrors = [StackMirror.from_dict(d) for d in stack_info['mirrors']]
 

--- a/catpy/image.py
+++ b/catpy/image.py
@@ -392,6 +392,12 @@ class Stack(object):
 
 
 class ProjectStack(Stack):
+    orientation_choices = {
+        0: "xy",
+        1: "xz",
+        2: "zy",
+    }
+
     def __init__(self, dimension, translation, resolution, orientation, broken_slices=None, canary_location=None):
         """
         Representation of an image stack as it pertains to a CATMAID project
@@ -430,7 +436,7 @@ class ProjectStack(Stack):
         """
         stack = cls(
             stack_info['dimension'], stack_info['translation'], stack_info['resolution'],
-            stack_info['orientation'], stack_info['broken_slices'], stack_info['canary_location']
+            cls.orientation_choices[stack_info['orientation']], stack_info['broken_slices'], stack_info['canary_location']
         )
         mirrors = [StackMirror.from_dict(d) for d in stack_info['mirrors']]
 


### PR DESCRIPTION
Resolves #24

ProjectStack expects a string orientation (e.g. "xy") but the stack_info
endpoint returns the integer form. from_stack_info now converts it.