### PR TITLE
Export: Add networkx 2 compatibility

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+In progress
+-----------
+
+* Allow networkx 2+ to be used
+
+
 0.2.0 (2018-05-30)
 ------------------
 

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,6 +1,6 @@
 enum34==1.1.6; python_version < "3.4"
 futures==3.2.0; python_version < "3.3"
-networkx==1.11
+networkx==2.2
 numpy==1.12.1
 Pillow==5.0.0
 requests==2.14.2

--- a/setup.py
+++ b/setup.py
@@ -19,15 +19,23 @@ with open(os.path.join(here, 'catpy', 'author.py')) as f:
     exec(f.read())
 
 requirements = [
-    'enum34>=1.1; python_version < "3.4"',
-    'futures>=3.2; python_version < "3.3"',
-    'networkx==1.11',
+    "enum34>=1.1; python_version < '3.4'",
+    "futures>=3.2; python_version < '3.3'",
+    'networkx>=1.11',
     'numpy>=1.12',
     'Pillow>=5.0',
     'requests>=2.14',
     'requests-futures>=0.9',
     'six>=1.10'
 ]
+
+# environment variable can force a specific networkx requirement, for testing purposes (see tox.ini)
+nx_version = os.environ.get('CATPY_NX')
+if nx_version:
+    requirements = [
+        r if not r.startswith('networkx') else "networkx" + nx_version
+        for r in requirements
+    ]
 
 setup_requirements = [
     'pytest-runner>=2.11',
@@ -68,6 +76,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
     ],
     setup_requires=setup_requirements,

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,0 +1,6 @@
+import os
+
+TEST_ROOT = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.dirname(TEST_ROOT)
+
+FIXTURE_ROOT = os.path.join(TEST_ROOT, "fixtures")

--- a/tests/fixtures/nodelink-nx1-11.json
+++ b/tests/fixtures/nodelink-nx1-11.json
@@ -1,0 +1,48 @@
+{
+  "directed": true,
+  "graph": {},
+  "links": [
+    {
+      "angle": 45,
+      "length": 20,
+      "source": 0,
+      "target": 1
+    },
+    {
+      "angle": 45,
+      "length": 20,
+      "source": 1,
+      "target": 2
+    },
+    {
+      "angle": 45,
+      "length": 20,
+      "source": 1,
+      "target": 0
+    },
+    {
+      "angle": 45,
+      "length": 20,
+      "source": 2,
+      "target": 0
+    }
+  ],
+  "multigraph": false,
+  "nodes": [
+    {
+      "colour": "r",
+      "id": 10,
+      "size": 10
+    },
+    {
+      "colour": "r",
+      "id": 20,
+      "size": 10
+    },
+    {
+      "colour": "r",
+      "id": 30,
+      "size": 10
+    }
+  ]
+}

--- a/tests/fixtures/nodelink-nx2-2.json
+++ b/tests/fixtures/nodelink-nx2-2.json
@@ -1,0 +1,48 @@
+{
+  "directed": true,
+  "graph": {},
+  "links": [
+    {
+      "angle": 45,
+      "length": 20,
+      "source": 10,
+      "target": 20
+    },
+    {
+      "angle": 45,
+      "length": 20,
+      "source": 20,
+      "target": 30
+    },
+    {
+      "angle": 45,
+      "length": 20,
+      "source": 20,
+      "target": 10
+    },
+    {
+      "angle": 45,
+      "length": 20,
+      "source": 30,
+      "target": 10
+    }
+  ],
+  "multigraph": false,
+  "nodes": [
+    {
+      "colour": "r",
+      "id": 10,
+      "size": 10
+    },
+    {
+      "colour": "r",
+      "id": 20,
+      "size": 10
+    },
+    {
+      "colour": "r",
+      "id": 30,
+      "size": 10
+    }
+  ]
+}

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,102 @@
+"""These tests dogfood really hard."""
+import json
+import os
+
+import networkx as nx
+from networkx.readwrite import json_graph
+
+import pytest
+
+from catpy.export import ExportWidget, convert_nodelink_data
+
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
+
+from tests.constants import FIXTURE_ROOT
+
+
+nx_version = tuple(int(i) for i in nx.__version__.split('.'))
+
+
+def assert_same_graph(g1, g2):
+    d1 = json_graph.node_link_data(g1)
+    d2 = json_graph.node_link_data(g2)
+    assert d1 == d2
+
+
+def get_json(version):
+    fpath = os.path.join(FIXTURE_ROOT, "nodelink-nx{}.json".format(version))
+    with open(fpath) as f:
+        return json.load(f)
+
+
+@pytest.fixture(params=["1-11"])  # , "2-2"])  # only need what CATMAID emits
+def nodelink_json(request):
+    return get_json(request.param)
+
+
+@pytest.fixture
+def expected_graph():
+    version = '1-11' if nx_version < (2, 0) else '2-2'
+
+    fpath = os.path.join(FIXTURE_ROOT, "nodelink-nx{}.json".format(version))
+    with open(fpath) as f:
+        return json_graph.node_link_graph(json.load(f))
+
+
+@pytest.fixture
+def export_widget():
+    catmaid = Mock()
+    catmaid.project_id = 1
+    return ExportWidget(catmaid)
+
+
+def test_reads_nodelinks(nodelink_json, export_widget, expected_graph):
+    """Check nodelink data is converted for nx2, not nx1"""
+    export_widget.get_networkx_dict = Mock(return_value=nodelink_json)
+    g = export_widget.get_networkx(10, 20, 30)
+    assert_same_graph(g, expected_graph)
+
+
+def test_converts():
+    v1, v2 = [get_json(v) for v in ['1-11', '2-2']]
+    assert convert_nodelink_data(v1) == v2
+
+
+def test_fails_to_convert():
+    v2 = get_json("2-2")
+    with pytest.raises(RuntimeError):
+        convert_nodelink_data(v2)
+
+
+@pytest.mark.skipif(nx_version < (2, 0), reason="Don't need to run this on networkx 1")
+def test_nx2_convert_nowarn(nodelink_json, expected_graph):
+    with pytest.warns(None) as record:
+        d = convert_nodelink_data(nodelink_json)
+    assert len(record) == 0
+    assert_same_graph(json_graph.node_link_graph(d), expected_graph)
+
+
+@pytest.mark.skipif(nx_version >= (2, 0), reason="Don't need to run this on networkx 2+")
+def test_nx1_convert_warn(nodelink_json):
+    # with pytest.warns(UserWarning):  # this assertion fails even though the warning is raised!
+    d = convert_nodelink_data(nodelink_json)
+
+    with pytest.raises(Exception):
+        json_graph.node_link_graph(d)
+
+
+def requirement_to_op_ver(s):
+    op = s[:2]
+    assert set('<>=').issuperset(op)
+    ver = s[2:]
+    assert set('0123456789.').issuperset(ver)
+    return op, ver
+
+
+@pytest.mark.skipif(not os.environ.get("CATPY_NX"), reason="No hard networkx version")
+def test_correct_nx():
+    op, ver = requirement_to_op_ver(os.environ["CATPY_NX"])
+    assert eval(nx.__version__ + op + ver)

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,18 @@
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py{27,34,35,36}-nx{1,2}
 
 [testenv]
 setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/catpy
     COVERAGE_FILE = .coverage.{envname}
+    nx1: CATPY_NX = ==1.11
+    nx2: CATPY_NX = >=2.0
 deps =
     -r{toxinidir}/requirements/dev.txt
 whitelist_externals =
     make
 commands =
     pip install -U pip
+    pip install -e .
     py.test --basetemp={envtmpdir} --cov=catpy --cov-report=
     make lint
 


### PR DESCRIPTION
Includes some sightly gross setup.py mangling to force builds with both
nx1 and nx2.

Will break (in an informative way) if CATMAID upgrades to nx2.